### PR TITLE
Add media-range matching support

### DIFF
--- a/src/PSR7/Validators/BodyValidator/BodyValidator.php
+++ b/src/PSR7/Validators/BodyValidator/BodyValidator.php
@@ -12,6 +12,7 @@ use OpenAPIValidation\PSR7\OperationAddress;
 use OpenAPIValidation\PSR7\SpecFinder;
 use OpenAPIValidation\PSR7\Validators\ValidationStrategy;
 use Psr\Http\Message\MessageInterface;
+use function explode;
 use function preg_match;
 use function strtok;
 
@@ -49,7 +50,8 @@ final class BodyValidator implements MessageValidator
         }
 
         // does the response contain one of described media types?
-        if (! ($mediaTypeSpec = $this->matchMediaTypeSpec($mediaTypeSpecs, $contentType))) {
+        $mediaTypeSpec = $this->matchMediaTypeSpec($mediaTypeSpecs, $contentType);
+        if ($mediaTypeSpec === null) {
             throw InvalidHeaders::becauseContentTypeIsNotExpected($contentType, $addr);
         }
 
@@ -93,20 +95,19 @@ final class BodyValidator implements MessageValidator
      * Match the spec from media type specs for the given media type.
      *
      * @param Reference[]|MediaType[] $mediaTypeSpecs
-     * @param string                  $mediaType
      *
-     * @return null|Reference|MediaType
+     * @return Reference|MediaType|null
      */
     private function matchMediaTypeSpec(array $mediaTypeSpecs, string $mediaType)
     {
-        [$mediaTypeType,] = explode('/', $mediaType);
+        [$mediaTypeType, $mediaTypeSubType] = explode('/', $mediaType);
 
         // Allow sub-type ranges and match all, like 'image/*', '*/*'
         // In the order: type/subtype > type/* > */*
         // see: https://tools.ietf.org/html/rfc7231#section-5.3.2
         $candidateContentTypes = [
             $mediaType,
-            $mediaTypeType .'/*',
+            $mediaTypeType . '/*',
             '*/*',
         ];
 

--- a/tests/PSR7/Validators/BodyValidatorTest.php
+++ b/tests/PSR7/Validators/BodyValidatorTest.php
@@ -18,26 +18,27 @@ class BodyValidatorTest extends TestCase
     {
         return [
             // Normal message
-                [
-                    __DIR__ . '/../../stubs/form-url-encoded.yaml',
-                    <<<HTTP
+            [
+                __DIR__ . '/../../stubs/form-url-encoded.yaml',
+                <<<HTTP
 POST /urlencoded/scalar-types HTTP/1.1
 Content-Length: 428
 Content-Type: application/x-www-form-urlencoded; charset=utf-8
 
 address=Moscow%2C+ulitsa+Rusakova%2C+d.15&id=59731930-a95a-11e9-a2a3-2a2ae2dbcce4&phones%5B0%5D=123-456&phones%5B1%5D=456-789&phones%5B%5D=101-112
 HTTP
-                ],
-                [
-                    __DIR__ . '/../../stubs/multi-media-types.yaml',
-                    <<<HTTP
+,
+            ],
+            [
+                __DIR__ . '/../../stubs/multi-media-types.yaml',
+                <<<HTTP
 GET /get-multi-media-type HTTP/1.1
 Accept: image/png
 
 
 HTTP
-                ,
-                ],
+,
+            ],
             [
                 __DIR__ . '/../../stubs/multi-media-types.yaml',
                 <<<HTTP
@@ -46,7 +47,7 @@ Accept: image/*
 
 
 HTTP
-                ,
+,
             ],
             [
                 __DIR__ . '/../../stubs/multi-media-types.yaml',
@@ -56,7 +57,7 @@ Accept: */*
 
 
 HTTP
-                ,
+,
             ],
         ];
     }

--- a/tests/PSR7/Validators/BodyValidatorTest.php
+++ b/tests/PSR7/Validators/BodyValidatorTest.php
@@ -12,32 +12,60 @@ use function GuzzleHttp\Psr7\parse_request;
 class BodyValidatorTest extends TestCase
 {
     /**
-     * @return array<array<string>> of arguments
+     * @return array<array<string,string>> of arguments
      */
-    public function dataProviderFormUrlencodedGreen() : array
+    public function dataProviderGreen() : array
     {
         return [
             // Normal message
-            [
-                <<<HTTP
+                [
+                    __DIR__ . '/../../stubs/form-url-encoded.yaml',
+                    <<<HTTP
 POST /urlencoded/scalar-types HTTP/1.1
 Content-Length: 428
 Content-Type: application/x-www-form-urlencoded; charset=utf-8
 
 address=Moscow%2C+ulitsa+Rusakova%2C+d.15&id=59731930-a95a-11e9-a2a3-2a2ae2dbcce4&phones%5B0%5D=123-456&phones%5B1%5D=456-789&phones%5B%5D=101-112
 HTTP
-,
+                ],
+                [
+                    __DIR__ . '/../../stubs/multi-media-types.yaml',
+                    <<<HTTP
+GET /get-multi-media-type HTTP/1.1
+Accept: image/png
+
+
+HTTP
+                ,
+                ],
+            [
+                __DIR__ . '/../../stubs/multi-media-types.yaml',
+                <<<HTTP
+GET /get-multi-media-type HTTP/1.1
+Accept: image/*
+
+
+HTTP
+                ,
+            ],
+            [
+                __DIR__ . '/../../stubs/multi-media-types.yaml',
+                <<<HTTP
+GET /get-multi-media-type HTTP/1.1
+Accept: */*
+
+
+HTTP
+                ,
             ],
         ];
     }
 
     /**
-     * @dataProvider dataProviderFormUrlencodedGreen
+     * @dataProvider dataProviderGreen
      */
-    public function testValidateFormUrlencodedGreen(string $message) : void
+    public function testValidateGreen(string $specFile, string $message) : void
     {
-        $specFile = __DIR__ . '/../../stubs/form-url-encoded.yaml';
-
         $request       = parse_request($message); // convert a text HTTP message to a PSR7 message
         $serverRequest = new ServerRequest(
             $request->getMethod(),

--- a/tests/stubs/multi-media-types.yaml
+++ b/tests/stubs/multi-media-types.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.2
+info:
+  title: Multi Media Types API
+  version: 0.0.1
+paths:
+  /get-multi-media-type:
+    get:
+      summary: Get multi-media-type body
+      operationId: get-multi-media-type
+      responses:
+        200:
+          description: media image
+          content:
+            'image/png':
+              schema:
+                type: string
+                format: binary
+            'image/*':
+              schema:
+                type: string
+                format: binary
+            '*/*':
+              schema:
+                type: string
+                format: binary
+


### PR DESCRIPTION
Support media ranges in response like `image/*`, `*/*`

https://tools.ietf.org/html/rfc7231#section-5.3.2

