### PR TITLE
Add missing failing tests

### DIFF
--- a/src/Schema/Keywords/Type.php
+++ b/src/Schema/Keywords/Type.php
@@ -14,6 +14,7 @@ use RuntimeException;
 use function class_exists;
 use function is_array;
 use function is_bool;
+use function is_float;
 use function is_int;
 use function is_numeric;
 use function is_object;
@@ -51,7 +52,8 @@ class Type extends BaseKeyword
                 }
                 break;
             case CebeType::BOOLEAN:
-                if (! is_bool($data) && ! preg_match('#^(true|false)$#i', (string) $data)) {
+                $stringifiedBool = is_scalar($data) && preg_match('#^(true|false)$#i', (string) $data);
+                if (! is_bool($data) && ! $stringifiedBool) {
                     throw TypeMismatch::becauseTypeDoesNotMatch(CebeType::BOOLEAN, $data);
                 }
                 break;
@@ -61,8 +63,8 @@ class Type extends BaseKeyword
                 }
                 break;
             case CebeType::INTEGER:
-                $stringifiedInt = preg_match('#^[-+]?\d+$#', (string) $data) && !is_float($data);
-                if (is_scalar($data) && ! is_int($data) && !$stringifiedInt) {
+                $stringifiedInt = is_scalar($data) && preg_match('#^[-+]?\d+$#', (string) $data) && ! is_float($data);
+                if (! is_int($data) && ! $stringifiedInt) {
                     throw TypeMismatch::becauseTypeDoesNotMatch(CebeType::INTEGER, $data);
                 }
                 break;

--- a/src/Schema/Keywords/Type.php
+++ b/src/Schema/Keywords/Type.php
@@ -51,7 +51,7 @@ class Type extends BaseKeyword
                 }
                 break;
             case CebeType::BOOLEAN:
-                if (is_scalar($data) && ! is_bool($data) && ! preg_match('#^(true|false)$#i', (string) $data)) {
+                if (! is_bool($data) && ! preg_match('#^(true|false)$#i', (string) $data)) {
                     throw TypeMismatch::becauseTypeDoesNotMatch(CebeType::BOOLEAN, $data);
                 }
                 break;
@@ -61,7 +61,8 @@ class Type extends BaseKeyword
                 }
                 break;
             case CebeType::INTEGER:
-                if (is_scalar($data) && ! is_int($data) && ! preg_match('#^[-+]?\d+$#', (string) $data)) {
+                $stringifiedInt = preg_match('#^[-+]?\d+$#', (string) $data) && !is_float($data);
+                if (is_scalar($data) && ! is_int($data) && !$stringifiedInt) {
                     throw TypeMismatch::becauseTypeDoesNotMatch(CebeType::INTEGER, $data);
                 }
                 break;

--- a/tests/Schema/Keywords/TypeTest.php
+++ b/tests/Schema/Keywords/TypeTest.php
@@ -7,6 +7,7 @@ namespace OpenAPIValidationTests\Schema\Keywords;
 use OpenAPIValidation\Schema\Exception\TypeMismatch;
 use OpenAPIValidation\Schema\SchemaValidator;
 use OpenAPIValidationTests\Schema\SchemaValidatorTest;
+use stdClass;
 
 final class TypeTest extends SchemaValidatorTest
 {
@@ -91,6 +92,7 @@ SPEC;
             ['boolean', [1, 2]],
             ['number', []],
             ['integer', 12.55],
+            ['integer', new stdClass()],
             ['integer', 1.0],
         ];
     }

--- a/tests/Schema/Keywords/TypeTest.php
+++ b/tests/Schema/Keywords/TypeTest.php
@@ -61,27 +61,37 @@ SPEC;
         $this->addToAssertionCount(1);
     }
 
-    public function testItValidatesTypeRed() : void
+    /**
+     * @param mixed $invalidValue
+     *
+     * @dataProvider invalidDataProvider
+     */
+    public function testItValidatesTypeRed(string $type, $invalidValue) : void
     {
-        $typedValues = [
-            'string'  => 12,
-            'object'  => 'not object',
-            'array'   => ['a' => 1, 'b' => 2], // this is not a plain array (ala JSON)
-            'boolean' => [1, 2],
-            'number'  => [],
-            'integer' => 12.55,
-        ];
-
-        foreach ($typedValues as $type => $invalidValue) {
-            $spec = <<<SPEC
+        $spec = <<<SPEC
 schema:
-  type: $type
+  type: $type\n
 SPEC;
 
-            $schema = $this->loadRawSchema($spec);
+        $schema = $this->loadRawSchema($spec);
 
-            $this->expectException(TypeMismatch::class);
-            (new SchemaValidator())->validate($invalidValue, $schema);
-        }
+        $this->expectException(TypeMismatch::class);
+        (new SchemaValidator())->validate($invalidValue, $schema);
+    }
+
+    /**
+     * @return array<array<string, mixed>>
+     */
+    public function invalidDataProvider() : array
+    {
+        return [
+            ['string', 12],
+            ['object', 'not object'],
+            ['array', ['a' => 1, 'b' => 2]], // this is not a plain array (a-la JSON)
+            ['boolean', [1, 2]],
+            ['number', []],
+            ['integer', 12.55],
+            ['integer', 1.0],
+        ];
     }
 }


### PR DESCRIPTION
While reading #10 I noticed some edge cases are not properly validated in `\OpenAPIValidation\Schema\Keywords\Type`.

Added two tests which are failing now (we missed them):
- 1.0 should not be validated as integer
- [1,2] should not be validated as boolean