### PR TITLE
Add throws MultipleOperationsMismatchForRequest

### DIFF
--- a/src/PSR7/ServerRequestValidator.php
+++ b/src/PSR7/ServerRequestValidator.php
@@ -49,6 +49,7 @@ class ServerRequestValidator implements ReusableSchema
     /**
      * @return OperationAddress which matched the Request
      *
+     * @throws MultipleOperationsMismatchForRequest
      * @throws ValidationFailed
      */
     public function validate(ServerRequestInterface $serverRequest) : OperationAddress


### PR DESCRIPTION
The ServerRequestValidator was missing a throws for MultipleOperationsMismatchForRequest which might catch some IDE's off guard.