### PR TITLE
Allow milliseconds in date-time format. Fixes #19

### DIFF
--- a/src/Schema/TypeFormats/StringDateTime.php
+++ b/src/Schema/TypeFormats/StringDateTime.php
@@ -10,8 +10,9 @@ class StringDateTime
 {
     public function __invoke(string $value) : bool
     {
-        // the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
-
-        return DateTime::createFromFormat(DateTime::RFC3339, $value) !== false;
+        // the date-time notation as defined by RFC 3339, section 5.6,
+        // for example, 2017-07-21T17:32:28Z or with optional fractional seconds, 2017-07-21T17:32:28.123Z
+        return DateTime::createFromFormat(DateTime::RFC3339, $value) !== false
+               || DateTime::createFromFormat(DateTime::RFC3339_EXTENDED, $value) !== false;
     }
 }

--- a/tests/FromCommunity/Issue19Test.php
+++ b/tests/FromCommunity/Issue19Test.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPIValidationTests\FromCommunity;
+
+use GuzzleHttp\Psr7\ServerRequest;
+use OpenAPIValidation\PSR7\Exception\ValidationFailed;
+use OpenAPIValidation\PSR7\ServerRequestValidator;
+use OpenAPIValidation\PSR7\ValidatorBuilder;
+use PHPUnit\Framework\TestCase;
+use function json_encode;
+
+/**
+ * @see https://github.com/thephpleague/openapi-psr7-validator/issues/19
+ */
+final class Issue19Test extends TestCase
+{
+    /** @var string $yamlFile */
+    private $yamlFile = __DIR__ . '/../stubs/date-times.yaml';
+    /** @var ServerRequestValidator $validator */
+    private $validator;
+
+    protected function setUp() : void
+    {
+        parent::setUp();
+        $this->validator = (new ValidatorBuilder())->fromYamlFile($this->yamlFile)->getServerRequestValidator();
+    }
+
+    public function testInvalidDateTime() : void
+    {
+        // For regression testing, try a date-time without a time zone (ie. an invalid value)
+        $this->expectException(ValidationFailed::class);
+        $this->validator->validate($this->makeRequest('2019-10-11T08:03:43'));
+    }
+
+    public function testDateTime() : void
+    {
+        // For regression testing, try the currently allowed date time format
+        $this->validator->validate($this->makeRequest('2019-10-11T08:03:43Z'));
+        $this->addToAssertionCount(1);
+    }
+
+    public function testDateTimeWithMilliseconds() : void
+    {
+        $this->validator->validate($this->makeRequest('2019-10-11T08:03:43.500Z'));
+        $this->addToAssertionCount(1);
+    }
+
+    protected function makeRequest(string $dateTimeString) : ServerRequest
+    {
+        $data['createdAt'] = $dateTimeString;
+        $body              = json_encode($data);
+
+        return new ServerRequest(
+            'POST',
+            'http://localhost:8000/products.create',
+            ['Content-Type' => 'application/json'],
+            $body
+        );
+    }
+}

--- a/tests/stubs/date-times.yaml
+++ b/tests/stubs/date-times.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.0
+info:
+  title: Product import API
+  version: '1.0'
+servers:
+  - url: 'http://localhost:8000'
+paths:
+  /products.create:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                createdAt:
+                  type: string
+                  format: 'date-time'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                properties:
+                  result:
+                    type: string


### PR DESCRIPTION
Fixes #19 

Although #20 has also been submitted to fix the same issue, as I'd already written this I'll push it up and let the maintainers decide which one to use.