### PR TITLE
Allow only assoc arrays as objects

### DIFF
--- a/src/Schema/Keywords/Type.php
+++ b/src/Schema/Keywords/Type.php
@@ -42,7 +42,7 @@ class Type extends BaseKeyword
     {
         switch ($type) {
             case CebeType::OBJECT:
-                if (! is_object($data) && ! is_array($data)) {
+                if (! is_object($data) && ! (is_array($data) && ArrayHelper::isAssoc($data))) {
                     throw TypeMismatch::becauseTypeDoesNotMatch(CebeType::OBJECT, $data);
                 }
                 break;

--- a/tests/Schema/Keywords/UniqueItemsTest.php
+++ b/tests/Schema/Keywords/UniqueItemsTest.php
@@ -89,7 +89,7 @@ schema:
   uniqueItems: true
 SPEC
 ,
-                [(array) (object) [1, 2], (array) (object) [3, 4]],
+                [['a' => 1, 'b' => 2], ['a' => 3, 'b' => 4]],
             ],
             [
                 <<<SPEC
@@ -102,7 +102,7 @@ schema:
   uniqueItems: true
 SPEC
 ,
-                [[(array) (object) [1, 2], (array) (object) [3, 4]], [(array) (object) [1, 2], (array) (object) [1, 2]]],
+                [[['a' => 1, 'b' => 2], ['a' => 3, 'b' => 4]], [['a' => 1, 'b' => 2], ['a' => 1, 'b' => 2]]],
             ],
             [
                 <<<SPEC
@@ -116,7 +116,7 @@ schema:
   uniqueItems: true
 SPEC
 ,
-                [[(array) (object) [1, 2], (array) (object) [3, 4]], [(array) (object) [1, 2], (array) (object) [3, 5]]],
+                [[['a' => 1, 'b' => 2], ['a' => 3, 'b' => 4]], [['a' => 1, 'b' => 2], ['a' => 3, 'b' => 5]]],
             ],
         ];
     }
@@ -169,7 +169,7 @@ schema:
   uniqueItems: true
 SPEC
 ,
-                [(array) (object) [1, 2], (array) (object) [1, 2]],
+                [['a' => 1, 'b' => 2], ['a' => 1, 'b' => 2]],
             ],
             [
                 <<<SPEC
@@ -182,7 +182,7 @@ schema:
   uniqueItems: true
 SPEC
 ,
-                [[(array) (object) [1, 2], (array) (object) [3, 4]], [(array) (object) [1, 2], (array) (object) [3, 4]]],
+                [[['a' => 1, 'b' => 2], ['a' => 3, 'b' => 4]], [['a' => 1, 'b' => 2], ['a' => 3, 'b' => 4]]],
             ],
             [
                 <<<SPEC
@@ -196,7 +196,7 @@ schema:
   uniqueItems: true
 SPEC
 ,
-                [[(array) (object) [1, 2], (array) (object) [3, 4]], [(array) (object) [1, 2], (array) (object) [1, 2]]],
+                [[['a' => 1, 'b' => 2], ['a' => 3, 'b' => 4]], [['a' => 1, 'b' => 2], ['a' => 1, 'b' => 2]]],
             ],
         ];
     }


### PR DESCRIPTION
Fix bug when vector was allowed as object