### PR TITLE
Removed duplicate reference resolves

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=7.2",
         "ext-json": "*",
-        "cebe/php-openapi": "^1.2",
+        "cebe/php-openapi": "^1.3",
         "dflydev/fig-cookies": "^2.0",
         "psr/cache": "^1.0",
         "psr/http-message": "^1.0",

--- a/src/PSR7/SchemaFactory/JsonFileFactory.php
+++ b/src/PSR7/SchemaFactory/JsonFileFactory.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace OpenAPIValidation\PSR7\SchemaFactory;
 
 use cebe\openapi\Reader;
-use cebe\openapi\ReferenceContext;
 use cebe\openapi\spec\OpenApi;
 use function realpath;
 
@@ -13,10 +12,8 @@ final class JsonFileFactory extends FileFactory
 {
     public function createSchema() : OpenApi
     {
-        $schema = Reader::readFromJsonFile($this->getFilename());
-
-        $schema->resolveReferences(new ReferenceContext($schema, realpath($this->getFilename())));
-
-        return $schema;
+        return Reader::readFromJsonFile(
+            realpath($this->getFilename())
+        );
     }
 }

--- a/src/PSR7/SchemaFactory/YamlFileFactory.php
+++ b/src/PSR7/SchemaFactory/YamlFileFactory.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace OpenAPIValidation\PSR7\SchemaFactory;
 
 use cebe\openapi\Reader;
-use cebe\openapi\ReferenceContext;
 use cebe\openapi\spec\OpenApi;
 use function realpath;
 
@@ -13,10 +12,8 @@ final class YamlFileFactory extends FileFactory
 {
     public function createSchema() : OpenApi
     {
-        $schema = Reader::readFromYamlFile($this->getFilename());
-
-        $schema->resolveReferences(new ReferenceContext($schema, realpath($this->getFilename())));
-
-        return $schema;
+        return Reader::readFromYamlFile(
+            realpath($this->getFilename())
+        );
     }
 }


### PR DESCRIPTION
As duplicate reference resolving is no longer required with `php-openapi v1.3.0` https://github.com/thephpleague/openapi-psr7-validator/issues/28 when the filename is provided with absolute path, I guess this can be removed.