### PR TITLE
Fix validation of empty objects

### DIFF
--- a/src/Schema/Keywords/Type.php
+++ b/src/Schema/Keywords/Type.php
@@ -42,7 +42,7 @@ class Type extends BaseKeyword
     {
         switch ($type) {
             case CebeType::OBJECT:
-                if (! is_object($data) && ! (is_array($data) && ArrayHelper::isAssoc($data))) {
+                if (! is_object($data) && ! (is_array($data) && ArrayHelper::isAssoc($data)) && $data !== []) {
                     throw TypeMismatch::becauseTypeDoesNotMatch(CebeType::OBJECT, $data);
                 }
                 break;

--- a/tests/FromCommunity/EmptyObjectValidationTest.php
+++ b/tests/FromCommunity/EmptyObjectValidationTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\OpenAPIValidation\Tests\FromCommunity;
+
+use GuzzleHttp\Psr7\ServerRequest;
+use League\OpenAPIValidation\PSR7\ValidatorBuilder;
+use PHPUnit\Framework\TestCase;
+use function GuzzleHttp\Psr7\stream_for;
+
+final class EmptyObjectValidationTest extends TestCase
+{
+    /**
+     * @see https://github.com/lezhnev74/openapi-psr7-validator/issues/57
+     */
+    public function testIssue57000() : void
+    {
+        $yaml = /** @lang yaml */
+            <<<YAML
+openapi: 3.0.0
+info:
+  title: Product import API
+  version: '1.0'
+servers:
+  - url: 'http://localhost:8000/api/v1'
+paths:
+  /products.create:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+YAML;
+
+        $validator = (new ValidatorBuilder())->fromYaml($yaml)->getServerRequestValidator();
+
+        $psrRequest = (new ServerRequest('post', 'http://localhost:8000/api/v1/products.create'))
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody(stream_for('{}'));
+
+        $validator->validate($psrRequest);
+
+        $this->addToAssertionCount(1);
+    }
+}


### PR DESCRIPTION
As the JSON payload is decoded into arrays, an empty array is not considered valid
for an object, even though it might come from an object.

https://github.com/thephpleague/openapi-psr7-validator/blob/master/src/PSR7/Validators/BodyValidator/UnipartValidator.php#L45

I think this broke after #24 