### PR TITLE
Rename variable in "Response message" chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ $validator = (new \League\OpenAPIValidation\PSR7\ValidatorBuilder)->fromSchema($
 
 $operation = new \League\OpenAPIValidation\PSR7\OperationAddress('/password/gen', 'get') ;
 
-$validator->validate($operation, $request);
+$validator->validate($operation, $response);
 ```
 
 ### Reuse Schema After Validation


### PR DESCRIPTION
Since the HTTP response should be validated, the variable should be called `$response` instead of `$request`.