### PR TITLE
Remove note on lack of `RequestInterface` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,6 @@ $validator = (new \League\OpenAPIValidation\PSR7\ValidatorBuilder)->fromYamlFile
 $openApi = $validator->getSchema();
 ```
 
-### Request Message
-`\Psr\Http\Message\RequestInterface` validation is not implemented. 
-
 ### PSR-15 Middleware
 PSR-15 middleware can be used like this:
 


### PR DESCRIPTION
It looks like support for `\Psr\Http\Message\RequestInterface` was added, but the old notice about lack of support is still there.