### PR TITLE
Strict types validation (fix #48)

### DIFF
--- a/src/PSR7/Exception/Validation/InvalidParameter.php
+++ b/src/PSR7/Exception/Validation/InvalidParameter.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\OpenAPIValidation\PSR7\Exception\Validation;
+
+use League\OpenAPIValidation\PSR7\OperationAddress;
+use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
+
+class InvalidParameter extends AddressValidationFailed
+{
+    /** @var string */
+    protected $name;
+
+    /** @var mixed */
+    protected $value;
+
+    /**
+     * @param mixed $value
+     */
+    public static function becauseValueDidNotMatchSchema(string $name, $value, OperationAddress $addr, SchemaMismatch $prev) : self
+    {
+        $exception        = static::fromAddrAndPrev($addr, $prev);
+        $exception->name  = $name;
+        $exception->value = $value;
+
+        return $exception;
+    }
+
+    public function name() : string
+    {
+        return $this->name;
+    }
+
+    public function value() : string
+    {
+        return (string) $this->value;
+    }
+}

--- a/src/PSR7/Exception/Validation/InvalidParameter.php
+++ b/src/PSR7/Exception/Validation/InvalidParameter.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace League\OpenAPIValidation\PSR7\Exception\Validation;
 
-use League\OpenAPIValidation\PSR7\OperationAddress;
+use League\OpenAPIValidation\PSR7\Exception\ValidationFailed;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
+use function sprintf;
 
-class InvalidParameter extends AddressValidationFailed
+class InvalidParameter extends ValidationFailed
 {
     /** @var string */
     protected $name;
@@ -17,10 +18,12 @@ class InvalidParameter extends AddressValidationFailed
 
     /**
      * @param mixed $value
+     *
+     * @return InvalidParameter
      */
-    public static function becauseValueDidNotMatchSchema(string $name, $value, OperationAddress $addr, SchemaMismatch $prev) : self
+    public static function becauseValueDidNotMatchSchema(string $name, $value, SchemaMismatch $prev) : self
     {
-        $exception        = static::fromAddrAndPrev($addr, $prev);
+        $exception        = new self(sprintf("Parameter '%s' has invalid value '%s'", $name, $value), 0, $prev);
         $exception->name  = $name;
         $exception->value = $value;
 

--- a/src/PSR7/Exception/Validation/RequiredParameterMissing.php
+++ b/src/PSR7/Exception/Validation/RequiredParameterMissing.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace League\OpenAPIValidation\PSR7\Exception\Validation;
 
-use League\OpenAPIValidation\PSR7\OperationAddress;
+use League\OpenAPIValidation\PSR7\Exception\ValidationFailed;
 
-class RequiredParameterMissing extends AddressValidationFailed
+class RequiredParameterMissing extends ValidationFailed
 {
     /** @var string */
     protected $name;
 
-    public static function fromNameAndAddr(string $name, OperationAddress $addr) : self
+    public static function fromName(string $name) : self
     {
-        $exception       = static::fromAddr($addr);
+        $exception       = new self();
         $exception->name = $name;
 
         return $exception;

--- a/src/PSR7/Exception/Validation/RequiredParameterMissing.php
+++ b/src/PSR7/Exception/Validation/RequiredParameterMissing.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\OpenAPIValidation\PSR7\Exception\Validation;
+
+use League\OpenAPIValidation\PSR7\OperationAddress;
+
+class RequiredParameterMissing extends AddressValidationFailed
+{
+    /** @var string */
+    protected $name;
+
+    public static function fromNameAndAddr(string $name, OperationAddress $addr) : self
+    {
+        $exception       = static::fromAddr($addr);
+        $exception->name = $name;
+
+        return $exception;
+    }
+
+    public function name() : string
+    {
+        return $this->name;
+    }
+}

--- a/src/PSR7/Validators/ArrayValidator.php
+++ b/src/PSR7/Validators/ArrayValidator.php
@@ -7,7 +7,6 @@ namespace League\OpenAPIValidation\PSR7\Validators;
 use cebe\openapi\spec\Parameter;
 use League\OpenAPIValidation\PSR7\Exception\Validation\InvalidParameter;
 use League\OpenAPIValidation\PSR7\Exception\Validation\RequiredParameterMissing;
-use League\OpenAPIValidation\PSR7\OperationAddress;
 use League\OpenAPIValidation\Schema\BreadCrumb;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\SchemaValidator;
@@ -35,11 +34,11 @@ class ArrayValidator
      * @throws InvalidParameter
      * @throws RequiredParameterMissing
      */
-    public function validateArray(OperationAddress $addr, array $params, int $validationStrategy) : void
+    public function validateArray(array $params, int $validationStrategy) : void
     {
         foreach ($this->specs as $name => $spec) {
             if ($spec->required && ! array_key_exists($name, $params)) {
-                throw RequiredParameterMissing::fromNameAndAddr($name, $addr);
+                throw RequiredParameterMissing::fromName($name);
             }
         }
 
@@ -56,7 +55,7 @@ class ArrayValidator
             try {
                 $validator->validate($parameter->deserialize($argumentValue), $parameter->getSchema(), new BreadCrumb($name));
             } catch (SchemaMismatch $e) {
-                throw InvalidParameter::becauseValueDidNotMatchSchema($name, $argumentValue, $addr, $e);
+                throw InvalidParameter::becauseValueDidNotMatchSchema($name, $argumentValue, $e);
             }
         }
     }

--- a/src/PSR7/Validators/ArrayValidator.php
+++ b/src/PSR7/Validators/ArrayValidator.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\OpenAPIValidation\PSR7\Validators;
+
+use cebe\openapi\spec\Parameter;
+use League\OpenAPIValidation\PSR7\Exception\Validation\InvalidParameter;
+use League\OpenAPIValidation\PSR7\Exception\Validation\RequiredParameterMissing;
+use League\OpenAPIValidation\PSR7\OperationAddress;
+use League\OpenAPIValidation\Schema\BreadCrumb;
+use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
+use League\OpenAPIValidation\Schema\SchemaValidator;
+use function array_key_exists;
+
+/**
+ * Validates given array against given specs
+ */
+class ArrayValidator
+{
+    /** @var Parameter[] */
+    private $specs;
+
+    /**
+     * @param Parameter[] $specs
+     */
+    public function __construct(array $specs)
+    {
+        $this->specs = $specs;
+    }
+
+    /**
+     * @param mixed[] $params
+     *
+     * @throws InvalidParameter
+     * @throws RequiredParameterMissing
+     */
+    public function validateArray(OperationAddress $addr, array $params, int $validationStrategy) : void
+    {
+        foreach ($this->specs as $name => $spec) {
+            if ($spec->required && ! array_key_exists($name, $params)) {
+                throw RequiredParameterMissing::fromNameAndAddr($name, $addr);
+            }
+        }
+
+        // Note: By default, OpenAPI treats all request parameters as optional.
+        $validator = new SchemaValidator($validationStrategy);
+
+        foreach ($params as $name => $argumentValue) {
+            // skip if there is no spec for this argument
+            if (! array_key_exists($name, $this->specs)) {
+                continue;
+            }
+
+            $parameter = SerializedParameter::fromSpec($this->specs[$name]);
+            try {
+                $validator->validate($parameter->deserialize($argumentValue), $parameter->getSchema(), new BreadCrumb($name));
+            } catch (SchemaMismatch $e) {
+                throw InvalidParameter::becauseValueDidNotMatchSchema($name, $argumentValue, $addr, $e);
+            }
+        }
+    }
+}

--- a/src/PSR7/Validators/BodyValidator/BodyDeserialization.php
+++ b/src/PSR7/Validators/BodyValidator/BodyDeserialization.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\OpenAPIValidation\PSR7\Validators\BodyValidator;
+
+use cebe\openapi\spec\Schema;
+use cebe\openapi\spec\Type as CebeType;
+use League\OpenAPIValidation\PSR7\Validators\SerializedParameter;
+use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
+
+trait BodyDeserialization
+{
+    /**
+     * @param array<string, mixed> $body
+     *
+     * @return array<string, mixed> $body
+     *
+     * @throws SchemaMismatch
+     */
+    protected function deserializeBody(array $body, Schema $schema) : array
+    {
+        if ($schema->type !== CebeType::OBJECT) {
+            return $body;
+        }
+
+        foreach ($schema->properties as $propName => $propSchema) {
+            if (! isset($body[$propName])) {
+                continue;
+            }
+
+            $param           = new SerializedParameter($propSchema);
+            $body[$propName] = $param->deserialize($body[$propName]);
+        }
+
+        return $body;
+    }
+}

--- a/src/PSR7/Validators/BodyValidator/FormUrlencodedValidator.php
+++ b/src/PSR7/Validators/BodyValidator/FormUrlencodedValidator.php
@@ -25,6 +25,7 @@ use function parse_str;
 class FormUrlencodedValidator implements MessageValidator
 {
     use ValidationStrategy;
+    use BodyDeserialization;
 
     /** @var MediaType */
     protected $mediaTypeSpec;
@@ -52,10 +53,10 @@ class FormUrlencodedValidator implements MessageValidator
         }
 
         // 1. Parse message body
-        $body = $this->parseUrlencodedData($message);
 
         $validator = new SchemaValidator($this->detectValidationStrategy($message));
         try {
+            $body = $this->deserializeBody($this->parseUrlencodedData($message), $schema);
             $validator->validate($body, $schema);
         } catch (SchemaMismatch $e) {
             throw InvalidBody::becauseBodyDoesNotMatchSchema($this->contentType, $addr, $e);

--- a/src/PSR7/Validators/BodyValidator/MultipartValidator.php
+++ b/src/PSR7/Validators/BodyValidator/MultipartValidator.php
@@ -15,6 +15,7 @@ use League\OpenAPIValidation\PSR7\Exception\Validation\InvalidHeaders;
 use League\OpenAPIValidation\PSR7\Exception\ValidationFailed;
 use League\OpenAPIValidation\PSR7\MessageValidator;
 use League\OpenAPIValidation\PSR7\OperationAddress;
+use League\OpenAPIValidation\PSR7\Validators\SerializedParameter;
 use League\OpenAPIValidation\PSR7\Validators\ValidationStrategy;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\Exception\TypeMismatch;
@@ -137,6 +138,7 @@ class MultipartValidator implements MessageValidator
                 }
 
                 // 2.2. parts headers
+                $validator = new SchemaValidator($this->detectValidationStrategy($message));
                 foreach ($encoding->headers as $headerName => $headerSpec) {
                     /** @var Header $headerSpec */
                     $headerSchema = $headerSpec->schema;
@@ -146,9 +148,9 @@ class MultipartValidator implements MessageValidator
                         throw InvalidHeaders::becauseOfMissingRequiredHeaderMupripart($partName, $headerName, $addr);
                     }
 
-                    $validator = new SchemaValidator($this->detectValidationStrategy($message));
+                    $header = SerializedParameter::fromSpec($headerSpec);
                     try {
-                        $validator->validate($headerValue, $headerSchema);
+                        $validator->validate($header->deserialize($headerValue), $headerSchema);
                     } catch (SchemaMismatch $e) {
                         throw InvalidHeaders::becauseValueDoesNotMatchSchemaMultipart($partName, $headerName, $headerValue, $addr, $e);
                     }

--- a/src/PSR7/Validators/BodyValidator/MultipartValidator.php
+++ b/src/PSR7/Validators/BodyValidator/MultipartValidator.php
@@ -41,6 +41,7 @@ use function strpos;
 class MultipartValidator implements MessageValidator
 {
     use ValidationStrategy;
+    use BodyDeserialization;
 
     private const HEADER_CONTENT_TYPE = 'Content-Type';
 
@@ -87,10 +88,9 @@ class MultipartValidator implements MessageValidator
         // 1. Parse message body
         $document = PSR7::convert($message);
 
-        $body = $this->parseMultipartData($addr, $document);
-
         $validator = new SchemaValidator($this->detectValidationStrategy($message));
         try {
+            $body = $this->deserializeBody($this->parseMultipartData($addr, $document), $schema);
             $validator->validate($body, $schema);
         } catch (SchemaMismatch $e) {
             throw InvalidBody::becauseBodyDoesNotMatchSchema($this->contentType, $addr, $e);

--- a/src/PSR7/Validators/CookiesValidator/RequestCookieValidator.php
+++ b/src/PSR7/Validators/CookiesValidator/RequestCookieValidator.php
@@ -10,7 +10,7 @@ use Dflydev\FigCookies\Cookies;
 use League\OpenAPIValidation\PSR7\Exception\Validation\InvalidCookies;
 use League\OpenAPIValidation\PSR7\MessageValidator;
 use League\OpenAPIValidation\PSR7\OperationAddress;
-use League\OpenAPIValidation\PSR7\Validators\RequestParameter;
+use League\OpenAPIValidation\PSR7\Validators\SerializedParameter;
 use League\OpenAPIValidation\PSR7\Validators\ValidationStrategy;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\SchemaValidator;
@@ -69,7 +69,7 @@ class RequestCookieValidator implements MessageValidator
                 continue;
             }
 
-            $parameter = RequestParameter::fromSpec($this->specs[$cookie->getName()]);
+            $parameter = SerializedParameter::fromSpec($this->specs[$cookie->getName()]);
             try {
                 $validator->validate($parameter->deserialize($cookie->getValue()), $parameter->getSchema());
             } catch (SchemaMismatch $e) {

--- a/src/PSR7/Validators/CookiesValidator/ServerRequestCookieValidator.php
+++ b/src/PSR7/Validators/CookiesValidator/ServerRequestCookieValidator.php
@@ -40,7 +40,7 @@ class ServerRequestCookieValidator implements MessageValidator
         $validator = new ArrayValidator($this->specs);
 
         try {
-            $validator->validateArray($addr, $message->getCookieParams(), $this->detectValidationStrategy($message));
+            $validator->validateArray($message->getCookieParams(), $this->detectValidationStrategy($message));
         } catch (RequiredParameterMissing $e) {
             throw InvalidCookies::becauseOfMissingRequiredCookie($e->name(), $addr);
         } catch (InvalidParameter $e) {

--- a/src/PSR7/Validators/CookiesValidator/ServerRequestCookieValidator.php
+++ b/src/PSR7/Validators/CookiesValidator/ServerRequestCookieValidator.php
@@ -6,16 +6,15 @@ namespace League\OpenAPIValidation\PSR7\Validators\CookiesValidator;
 
 use cebe\openapi\spec\Parameter;
 use League\OpenAPIValidation\PSR7\Exception\Validation\InvalidCookies;
+use League\OpenAPIValidation\PSR7\Exception\Validation\InvalidParameter;
+use League\OpenAPIValidation\PSR7\Exception\Validation\RequiredParameterMissing;
 use League\OpenAPIValidation\PSR7\MessageValidator;
 use League\OpenAPIValidation\PSR7\OperationAddress;
-use League\OpenAPIValidation\PSR7\Validators\SerializedParameter;
+use League\OpenAPIValidation\PSR7\Validators\ArrayValidator;
 use League\OpenAPIValidation\PSR7\Validators\ValidationStrategy;
-use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
-use League\OpenAPIValidation\Schema\SchemaValidator;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Webmozart\Assert\Assert;
-use function array_key_exists;
 
 class ServerRequestCookieValidator implements MessageValidator
 {
@@ -38,39 +37,14 @@ class ServerRequestCookieValidator implements MessageValidator
     public function validate(OperationAddress $addr, MessageInterface $message) : void
     {
         Assert::isInstanceOf($message, ServerRequestInterface::class);
-        $this->checkRequiredCookies($addr, $message);
-        $this->checkCookiesAgainstSchema($addr, $message);
-    }
+        $validator = new ArrayValidator($this->specs);
 
-    /**
-     * @throws InvalidCookies
-     */
-    private function checkRequiredCookies(OperationAddress $addr, ServerRequestInterface $message) : void
-    {
-        foreach ($this->specs as $cookieName => $spec) {
-            if ($spec->required && ! array_key_exists($cookieName, $message->getCookieParams())) {
-                throw InvalidCookies::becauseOfMissingRequiredCookie($cookieName, $addr);
-            }
-        }
-    }
-
-    /**
-     * @throws InvalidCookies
-     */
-    private function checkCookiesAgainstSchema(OperationAddress $addr, ServerRequestInterface $message) : void
-    {
-        foreach ($message->getCookieParams() as $cookieName => $cookieValue) {
-            if (! isset($this->specs[$cookieName])) {
-                continue;
-            }
-
-            $validator   = new SchemaValidator($this->detectValidationStrategy($message));
-            $cookieParam = SerializedParameter::fromSpec($this->specs[$cookieName]);
-            try {
-                $validator->validate($cookieParam->deserialize($cookieValue), $cookieParam->getSchema());
-            } catch (SchemaMismatch $e) {
-                throw InvalidCookies::becauseValueDoesNotMatchSchema($cookieName, $cookieValue, $addr, $e);
-            }
+        try {
+            $validator->validateArray($addr, $message->getCookieParams(), $this->detectValidationStrategy($message));
+        } catch (RequiredParameterMissing $e) {
+            throw InvalidCookies::becauseOfMissingRequiredCookie($e->name(), $addr);
+        } catch (InvalidParameter $e) {
+            throw InvalidCookies::becauseValueDoesNotMatchSchema($e->name(), $e->value(), $addr, $e->getPrevious());
         }
     }
 }

--- a/src/PSR7/Validators/CookiesValidator/ServerRequestCookieValidator.php
+++ b/src/PSR7/Validators/CookiesValidator/ServerRequestCookieValidator.php
@@ -8,6 +8,7 @@ use cebe\openapi\spec\Parameter;
 use League\OpenAPIValidation\PSR7\Exception\Validation\InvalidCookies;
 use League\OpenAPIValidation\PSR7\MessageValidator;
 use League\OpenAPIValidation\PSR7\OperationAddress;
+use League\OpenAPIValidation\PSR7\Validators\SerializedParameter;
 use League\OpenAPIValidation\PSR7\Validators\ValidationStrategy;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\SchemaValidator;
@@ -63,9 +64,10 @@ class ServerRequestCookieValidator implements MessageValidator
                 continue;
             }
 
-            $validator = new SchemaValidator($this->detectValidationStrategy($message));
+            $validator   = new SchemaValidator($this->detectValidationStrategy($message));
+            $cookieParam = SerializedParameter::fromSpec($this->specs[$cookieName]);
             try {
-                $validator->validate($cookieValue, $this->specs[$cookieName]->schema);
+                $validator->validate($cookieParam->deserialize($cookieValue), $cookieParam->getSchema());
             } catch (SchemaMismatch $e) {
                 throw InvalidCookies::becauseValueDoesNotMatchSchema($cookieName, $cookieValue, $addr, $e);
             }

--- a/src/PSR7/Validators/HeadersValidator.php
+++ b/src/PSR7/Validators/HeadersValidator.php
@@ -38,9 +38,11 @@ final class HeadersValidator implements MessageValidator
                 throw InvalidHeaders::becauseOfMissingRequiredHeader($header, $addr);
             }
 
+            $parameter = SerializedParameter::fromSpec($spec);
+
             foreach ($message->getHeader($header) as $headerValue) {
                 try {
-                    $validator->validate($headerValue, $spec->schema);
+                    $validator->validate($parameter->deserialize($headerValue), $spec->schema);
                 } catch (SchemaMismatch $exception) {
                     throw InvalidHeaders::becauseValueDoesNotMatchSchema($header, $headerValue, $addr, $exception);
                 }

--- a/src/PSR7/Validators/PathValidator.php
+++ b/src/PSR7/Validators/PathValidator.php
@@ -49,7 +49,7 @@ final class PathValidator implements MessageValidator
         $validator        = new SchemaValidator($this->detectValidationStrategy($message));
 
         foreach ($pathParsedParams as $name => $value) {
-            $parameter = RequestParameter::fromSpec($specs[$name]);
+            $parameter = SerializedParameter::fromSpec($specs[$name]);
             try {
                 $validator->validate($parameter->deserialize($value), $parameter->getSchema());
             } catch (SchemaMismatch $e) {

--- a/src/PSR7/Validators/PathValidator.php
+++ b/src/PSR7/Validators/PathValidator.php
@@ -7,9 +7,11 @@ namespace League\OpenAPIValidation\PSR7\Validators;
 use League\OpenAPIValidation\PSR7\Exception\NoPath;
 use League\OpenAPIValidation\PSR7\Exception\Validation\InvalidParameter;
 use League\OpenAPIValidation\PSR7\Exception\Validation\InvalidPath;
+use League\OpenAPIValidation\PSR7\Exception\Validation\RequiredParameterMissing;
 use League\OpenAPIValidation\PSR7\MessageValidator;
 use League\OpenAPIValidation\PSR7\OperationAddress;
 use League\OpenAPIValidation\PSR7\SpecFinder;
+use LogicException;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 
@@ -46,9 +48,12 @@ final class PathValidator implements MessageValidator
         $pathParsedParams = $addr->parseParams($path); // ['id'=>12]
 
         try {
-            $validator->validateArray($addr, $pathParsedParams, $this->detectValidationStrategy($message));
+            $validator->validateArray($pathParsedParams, $this->detectValidationStrategy($message));
         } catch (InvalidParameter $e) {
             throw InvalidPath::becauseValueDoesNotMatchSchema($e->name(), $e->value(), $addr, $e->getPrevious());
-        } // RequiredParameterMissing will not be thrown, all parameters are checking in parseParams
+        } catch (RequiredParameterMissing $e) {
+            throw new LogicException('RequiredParameterMissing should not be thrown in PathValidator, ' .
+                'because presence of all parameters have to be checked before', 0, $e);
+        }
     }
 }

--- a/src/PSR7/Validators/PathValidator.php
+++ b/src/PSR7/Validators/PathValidator.php
@@ -49,8 +49,9 @@ final class PathValidator implements MessageValidator
         $validator        = new SchemaValidator($this->detectValidationStrategy($message));
 
         foreach ($pathParsedParams as $name => $value) {
+            $parameter = RequestParameter::fromSpec($specs[$name]);
             try {
-                $validator->validate($value, $specs[$name]->schema);
+                $validator->validate($parameter->deserialize($value), $parameter->getSchema());
             } catch (SchemaMismatch $e) {
                 throw InvalidPath::becauseValueDoesNotMatchSchema($name, (string) $value, $addr, $e);
             }

--- a/src/PSR7/Validators/QueryArgumentsValidator.php
+++ b/src/PSR7/Validators/QueryArgumentsValidator.php
@@ -54,7 +54,7 @@ final class QueryArgumentsValidator implements MessageValidator
         $validator = new ArrayValidator($this->finder->findQuerySpecs($addr));
 
         try {
-            $validator->validateArray($addr, $parsedQueryArguments, $validationStrategy);
+            $validator->validateArray($parsedQueryArguments, $validationStrategy);
         } catch (RequiredParameterMissing $e) {
             throw InvalidQueryArgs::becauseOfMissingRequiredArgument($e->name(), $addr);
         } catch (InvalidParameter $e) {

--- a/src/PSR7/Validators/QueryArgumentsValidator.php
+++ b/src/PSR7/Validators/QueryArgumentsValidator.php
@@ -89,7 +89,7 @@ final class QueryArgumentsValidator implements MessageValidator
                 continue;
             }
 
-            $parameter = RequestParameter::fromSpec($specs[$name]);
+            $parameter = SerializedParameter::fromSpec($specs[$name]);
             try {
                 $validator->validate($parameter->deserialize($argumentValue), $parameter->getSchema(), new BreadCrumb($name));
             } catch (SchemaMismatch $e) {

--- a/src/PSR7/Validators/QueryArgumentsValidator.php
+++ b/src/PSR7/Validators/QueryArgumentsValidator.php
@@ -81,6 +81,7 @@ final class QueryArgumentsValidator implements MessageValidator
     private function validateAgainstSchema(OperationAddress $addr, array $parsedQueryArguments, int $validationStrategy, array $specs) : void
     {
         // Note: By default, OpenAPI treats all request parameters as optional.
+        $validator = new SchemaValidator($validationStrategy);
 
         foreach ($parsedQueryArguments as $name => $argumentValue) {
             // skip if there is no spec for this argument
@@ -89,10 +90,8 @@ final class QueryArgumentsValidator implements MessageValidator
             }
 
             $parameter = RequestParameter::fromSpec($specs[$name]);
-            $schema    = $parameter->getSchema();
-            $validator = new SchemaValidator($validationStrategy);
             try {
-                $validator->validate($parameter->deserialize($argumentValue), $schema, new BreadCrumb($name));
+                $validator->validate($parameter->deserialize($argumentValue), $parameter->getSchema(), new BreadCrumb($name));
             } catch (SchemaMismatch $e) {
                 throw InvalidQueryArgs::becauseValueDoesNotMatchSchema($name, $argumentValue, $addr, $e);
             }

--- a/src/PSR7/Validators/QueryArgumentsValidator.php
+++ b/src/PSR7/Validators/QueryArgumentsValidator.php
@@ -4,19 +4,16 @@ declare(strict_types=1);
 
 namespace League\OpenAPIValidation\PSR7\Validators;
 
-use cebe\openapi\spec\Parameter;
 use League\OpenAPIValidation\PSR7\Exception\NoPath;
+use League\OpenAPIValidation\PSR7\Exception\Validation\InvalidParameter;
 use League\OpenAPIValidation\PSR7\Exception\Validation\InvalidQueryArgs;
+use League\OpenAPIValidation\PSR7\Exception\Validation\RequiredParameterMissing;
 use League\OpenAPIValidation\PSR7\MessageValidator;
 use League\OpenAPIValidation\PSR7\OperationAddress;
 use League\OpenAPIValidation\PSR7\SpecFinder;
-use League\OpenAPIValidation\Schema\BreadCrumb;
-use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
-use League\OpenAPIValidation\Schema\SchemaValidator;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use function array_key_exists;
 use function parse_str;
 
 /**
@@ -54,47 +51,14 @@ final class QueryArgumentsValidator implements MessageValidator
      */
     private function validateQueryArguments(OperationAddress $addr, array $parsedQueryArguments, int $validationStrategy) : void
     {
-        $specs = $this->finder->findQuerySpecs($addr);
-        $this->checkMissingArguments($addr, $parsedQueryArguments, $specs);
-        $this->validateAgainstSchema($addr, $parsedQueryArguments, $validationStrategy, $specs);
-    }
+        $validator = new ArrayValidator($this->finder->findQuerySpecs($addr));
 
-    /**
-     * @param mixed[]     $parsedQueryArguments [limit=>10]
-     * @param Parameter[] $specs
-     */
-    private function checkMissingArguments(OperationAddress $addr, array $parsedQueryArguments, array $specs) : void
-    {
-        foreach ($specs as $name => $spec) {
-            if ($spec->required && ! array_key_exists($name, $parsedQueryArguments)) {
-                throw InvalidQueryArgs::becauseOfMissingRequiredArgument($name, $addr);
-            }
-        }
-    }
-
-    /**
-     * @param mixed[]     $parsedQueryArguments [limit=>10]
-     * @param Parameter[] $specs
-     *
-     * @throws InvalidQueryArgs
-     */
-    private function validateAgainstSchema(OperationAddress $addr, array $parsedQueryArguments, int $validationStrategy, array $specs) : void
-    {
-        // Note: By default, OpenAPI treats all request parameters as optional.
-        $validator = new SchemaValidator($validationStrategy);
-
-        foreach ($parsedQueryArguments as $name => $argumentValue) {
-            // skip if there is no spec for this argument
-            if (! array_key_exists($name, $specs)) {
-                continue;
-            }
-
-            $parameter = SerializedParameter::fromSpec($specs[$name]);
-            try {
-                $validator->validate($parameter->deserialize($argumentValue), $parameter->getSchema(), new BreadCrumb($name));
-            } catch (SchemaMismatch $e) {
-                throw InvalidQueryArgs::becauseValueDoesNotMatchSchema($name, $argumentValue, $addr, $e);
-            }
+        try {
+            $validator->validateArray($addr, $parsedQueryArguments, $validationStrategy);
+        } catch (RequiredParameterMissing $e) {
+            throw InvalidQueryArgs::becauseOfMissingRequiredArgument($e->name(), $addr);
+        } catch (InvalidParameter $e) {
+            throw InvalidQueryArgs::becauseValueDoesNotMatchSchema($e->name(), $e->value(), $addr, $e->getPrevious());
         }
     }
 

--- a/src/PSR7/Validators/RequestParameter.php
+++ b/src/PSR7/Validators/RequestParameter.php
@@ -6,6 +6,7 @@ namespace League\OpenAPIValidation\PSR7\Validators;
 
 use cebe\openapi\spec\Parameter as CebeParameter;
 use cebe\openapi\spec\Schema as CebeSchema;
+use cebe\openapi\spec\Type as CebeType;
 use League\OpenAPIValidation\Schema\Exception\ContentTypeMismatch;
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
@@ -13,6 +14,10 @@ use League\OpenAPIValidation\Schema\Exception\TypeMismatch;
 use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 use const JSON_ERROR_NONE;
+use function is_float;
+use function is_int;
+use function is_numeric;
+use function is_scalar;
 use function is_string;
 use function json_decode;
 use function json_last_error;
@@ -78,6 +83,20 @@ final class RequestParameter
             }
 
             return $decodedValue;
+        }
+
+        if (($this->schema->type === CebeType::BOOLEAN) && is_scalar($value) && preg_match('#^(true|false)$#i', (string) $value)) {
+            return (bool) $value;
+        }
+
+        if (($this->schema->type === CebeType::NUMBER)
+            && is_scalar($value) && is_numeric($value)) {
+            return is_int($value) ? (int) $value : (float) $value;
+        }
+
+        if (($this->schema->type === CebeType::INTEGER)
+            && is_scalar($value) && ! is_float($value) && preg_match('#^[-+]?\d+$#', (string) $value)) {
+            return (int) $value;
         }
 
         return $value;

--- a/src/PSR7/Validators/SerializedParameter.php
+++ b/src/PSR7/Validators/SerializedParameter.php
@@ -25,7 +25,7 @@ use function key;
 use function preg_match;
 use function reset;
 
-final class RequestParameter
+final class SerializedParameter
 {
     /** @var CebeSchema */
     private $schema;

--- a/src/Schema/Keywords/Type.php
+++ b/src/Schema/Keywords/Type.php
@@ -49,7 +49,7 @@ class Type extends BaseKeyword
                 }
                 break;
             case CebeType::BOOLEAN:
-                if (is_string($data) || ! is_bool($data)) {
+                if (! is_bool($data)) {
                     throw TypeMismatch::becauseTypeDoesNotMatch(CebeType::BOOLEAN, $data);
                 }
                 break;
@@ -59,7 +59,7 @@ class Type extends BaseKeyword
                 }
                 break;
             case CebeType::INTEGER:
-                if (is_string($data) || ! is_int($data)) {
+                if (! is_int($data)) {
                     throw TypeMismatch::becauseTypeDoesNotMatch(CebeType::INTEGER, $data);
                 }
                 break;

--- a/src/Schema/Keywords/Type.php
+++ b/src/Schema/Keywords/Type.php
@@ -14,13 +14,10 @@ use RuntimeException;
 use function class_exists;
 use function is_array;
 use function is_bool;
-use function is_float;
 use function is_int;
 use function is_numeric;
 use function is_object;
-use function is_scalar;
 use function is_string;
-use function preg_match;
 use function sprintf;
 
 class Type extends BaseKeyword
@@ -52,19 +49,17 @@ class Type extends BaseKeyword
                 }
                 break;
             case CebeType::BOOLEAN:
-                $stringifiedBool = is_scalar($data) && preg_match('#^(true|false)$#i', (string) $data);
-                if (! is_bool($data) && ! $stringifiedBool) {
+                if (is_string($data) || ! is_bool($data)) {
                     throw TypeMismatch::becauseTypeDoesNotMatch(CebeType::BOOLEAN, $data);
                 }
                 break;
             case CebeType::NUMBER:
-                if (! is_numeric($data)) {
+                if (is_string($data) || ! is_numeric($data)) {
                     throw TypeMismatch::becauseTypeDoesNotMatch(CebeType::NUMBER, $data);
                 }
                 break;
             case CebeType::INTEGER:
-                $stringifiedInt = is_scalar($data) && preg_match('#^[-+]?\d+$#', (string) $data) && ! is_float($data);
-                if (! is_int($data) && ! $stringifiedInt) {
+                if (is_string($data) || ! is_int($data)) {
                     throw TypeMismatch::becauseTypeDoesNotMatch(CebeType::INTEGER, $data);
                 }
                 break;

--- a/tests/PSR7/CookieDeserializeTest.php
+++ b/tests/PSR7/CookieDeserializeTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\OpenAPIValidation\Tests\PSR7;
+
+use GuzzleHttp\Psr7\ServerRequest;
+use GuzzleHttp\Psr7\Uri;
+use League\OpenAPIValidation\PSR7\Exception\Validation\InvalidCookies;
+use League\OpenAPIValidation\PSR7\ValidatorBuilder;
+use function sprintf;
+
+final class CookieDeserializeTest extends BaseValidatorTest
+{
+    public function testItDeserializesServerRequestCookieParametersGreen() : void
+    {
+        $request = (new ServerRequest('get', new Uri('/deserialize-cookies')))
+            ->withCookieParams([
+                'num' => '-1.2',
+                'int' => '414',
+                'bool' => 'true',
+            ]);
+
+        $validator = (new ValidatorBuilder())->fromYamlFile($this->apiSpecFile)->getServerRequestValidator();
+        $validator->validate($request);
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @return mixed[][]
+     */
+    public function dataProviderCookiesRed() : array
+    {
+        return [
+            ['num', '-'],
+            ['num', 'ac'],
+            ['int', 'ac'],
+            ['int', '1.0'],
+            ['bool', '1'],
+            ['bool', 'yes'],
+            ['bool', ''],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderCookiesRed
+     */
+    public function testItDeserializesServerRequestCookieParametersRed(string $cookieName, string $cookieValue) : void
+    {
+        $request = (new ServerRequest('get', new Uri('/deserialize-cookies')))
+            ->withCookieParams([$cookieName => $cookieValue]);
+
+        $validator = (new ValidatorBuilder())->fromYamlFile($this->apiSpecFile)->getServerRequestValidator();
+
+        $this->expectException(InvalidCookies::class);
+        $this->expectExceptionMessage(
+            sprintf('Value "%s" for cookie "%s" is invalid for Request [get /deserialize-cookies]', $cookieValue, $cookieName)
+        );
+        $validator->validate($request);
+    }
+}

--- a/tests/PSR7/HeadersTest.php
+++ b/tests/PSR7/HeadersTest.php
@@ -6,7 +6,9 @@ namespace League\OpenAPIValidation\Tests\PSR7;
 
 use GuzzleHttp\Psr7\ServerRequest;
 use GuzzleHttp\Psr7\Uri;
+use League\OpenAPIValidation\PSR7\Exception\Validation\InvalidHeaders;
 use League\OpenAPIValidation\PSR7\ValidatorBuilder;
+use function sprintf;
 
 final class HeadersTest extends BaseValidatorTest
 {
@@ -17,5 +19,50 @@ final class HeadersTest extends BaseValidatorTest
         $validator = (new ValidatorBuilder())->fromYamlFile($this->apiSpecFile)->getServerRequestValidator();
         $validator->validate($request);
         $this->addToAssertionCount(1);
+    }
+
+    public function testItDeserializesRequestHeaderParametersGreen() : void
+    {
+        $request = (new ServerRequest('get', new Uri('/deserialize-headers')))
+            ->withHeader('num', '-1.2')
+            ->withHeader('int', '414')
+            ->withHeader('bool', 'true');
+
+        $validator = (new ValidatorBuilder())->fromYamlFile($this->apiSpecFile)->getServerRequestValidator();
+        $validator->validate($request);
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @return mixed[][]
+     */
+    public function dataProviderDeserializesRequestHeaderRed() : array
+    {
+        return [
+            ['num', '-'],
+            ['num', 'ac'],
+            ['int', 'ac'],
+            ['int', '1.0'],
+            ['bool', '1'],
+            ['bool', 'yes'],
+            ['bool', ''],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderDeserializesRequestHeaderRed
+     */
+    public function testItDeserializesRequestHeaderParametersRed(string $headerName, string $headerValue) : void
+    {
+        $request = (new ServerRequest('get', new Uri('/deserialize-headers')))
+            ->withHeader($headerName, $headerValue);
+
+        $validator = (new ValidatorBuilder())->fromYamlFile($this->apiSpecFile)->getServerRequestValidator();
+
+        $this->expectException(InvalidHeaders::class);
+        $this->expectExceptionMessage(
+            sprintf('Value "%s" for header "%s" is invalid for Request [get /deserialize-headers]', $headerValue, $headerName)
+        );
+        $validator->validate($request);
     }
 }

--- a/tests/PSR7/Validators/BodyValidator/MultipartValidatorTest.php
+++ b/tests/PSR7/Validators/BodyValidator/MultipartValidatorTest.php
@@ -108,6 +108,7 @@ Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryWfPNVh4wuWBlyE
 Content-Disposition: form-data; name="image"; filename="file1.txt"
 Content-Type: specific/type
 X-Custom-Header: string value goes here
+X-Numeric-Header: 1
 
 [file content goes there]
 ------WebKitFormBoundaryWfPNVh4wuWBlyEyQ--
@@ -197,6 +198,25 @@ Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryWfPNVh4wuWBlyE
 Content-Disposition: form-data; name="image"; filename="file1.txt"
 Content-Type: specific/type
 X-Custom-Header-WRONG: string value goes here
+
+[file content goes there]
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ--
+HTTP
+,
+                InvalidHeaders::class,
+            ],
+            // wrong header format for one part
+            [
+                <<<HTTP
+POST /multipart/headers HTTP/1.1
+Content-Length: 2740
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+Content-Disposition: form-data; name="image"; filename="file1.txt"
+Content-Type: specific/type
+X-Custom-Header: string value goes here
+X-Numeric-Header: string value
 
 [file content goes there]
 ------WebKitFormBoundaryWfPNVh4wuWBlyEyQ--

--- a/tests/PSR7/Validators/BodyValidator/MultipartValidatorTest.php
+++ b/tests/PSR7/Validators/BodyValidator/MultipartValidatorTest.php
@@ -131,6 +131,32 @@ Content-Type: image/whatever
 HTTP
 ,
             ],
+            // deserialized values
+            [
+                <<<HTTP
+POST /multipart-deserialization HTTP/1.1
+Content-Length: 428
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryOmz20xyMCkE27rN7
+
+------WebKitFormBoundaryOmz20xyMCkE27rN7
+Content-Disposition: form-data; name="id"
+Content-Type: text/plain
+
+123.0
+------WebKitFormBoundaryOmz20xyMCkE27rN7
+Content-Disposition: form-data; name="secure"
+Content-Type: text/plain
+
+true
+------WebKitFormBoundaryOmz20xyMCkE27rN7
+Content-Disposition: form-data; name="code"
+Content-Type: text/plain
+
+456
+------WebKitFormBoundaryOmz20xyMCkE27rN7--
+HTTP
+,
+            ],
         ];
     }
 
@@ -223,6 +249,33 @@ X-Numeric-Header: string value
 HTTP
 ,
                 InvalidHeaders::class,
+            ],
+            // wrong data in one of the parts
+            [
+                <<<HTTP
+POST /multipart-deserialization HTTP/1.1
+Content-Length: 428
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryOmz20xyMCkE27rN7
+
+------WebKitFormBoundaryOmz20xyMCkE27rN7
+Content-Disposition: form-data; name="id"
+Content-Type: text/plain
+
+123
+------WebKitFormBoundaryOmz20xyMCkE27rN7
+Content-Disposition: form-data; name="secure"
+Content-Type: text/plain
+
+0
+------WebKitFormBoundaryOmz20xyMCkE27rN7
+Content-Disposition: form-data; name="code"
+Content-Type: text/plain
+
+456
+------WebKitFormBoundaryOmz20xyMCkE27rN7--
+HTTP
+,
+                InvalidBody::class,
             ],
         ];
     }

--- a/tests/PSR7/Validators/BodyValidatorTest.php
+++ b/tests/PSR7/Validators/BodyValidatorTest.php
@@ -79,6 +79,9 @@ HTTP
         ];
     }
 
+    /**
+     * @return array<array<string,string>> of arguments
+     */
     public function dataProviderRed() : array
     {
         return [

--- a/tests/PSR7/Validators/SerializedParameterTest.php
+++ b/tests/PSR7/Validators/SerializedParameterTest.php
@@ -6,12 +6,12 @@ namespace League\OpenAPIValidation\Tests\PSR7\Validators;
 
 use cebe\openapi\spec\Parameter;
 use cebe\openapi\spec\Schema;
-use League\OpenAPIValidation\PSR7\Validators\RequestParameter;
+use League\OpenAPIValidation\PSR7\Validators\SerializedParameter;
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use PHPUnit\Framework\TestCase;
 
-class RequestParameterTest extends TestCase
+class SerializedParameterTest extends TestCase
 {
     /**
      * @param mixed[] $parameterData
@@ -23,12 +23,12 @@ class RequestParameterTest extends TestCase
     public function testFromSpecThrowsInvalidSchemaExceptionIfParameterIsNotValid(array $parameterData) : void
     {
         $this->expectException(InvalidSchema::class);
-        RequestParameter::fromSpec(new Parameter($parameterData));
+        SerializedParameter::fromSpec(new Parameter($parameterData));
     }
 
     public function testDeserializeThrowsSchemaMismatchExceptionIfValueIsNotStringWhenShouldBeDeserialized() : void
     {
-        $subject = new RequestParameter($this->createMock(Schema::class), 'application/json');
+        $subject = new SerializedParameter($this->createMock(Schema::class), 'application/json');
 
         $this->expectException(SchemaMismatch::class);
         $this->expectExceptionMessage("Value expected to be 'string', 'array' given");

--- a/tests/Schema/Keywords/TypeTest.php
+++ b/tests/Schema/Keywords/TypeTest.php
@@ -22,20 +22,9 @@ final class TypeTest extends SchemaValidatorTest
             ['array', null, ['a', 'b']],
             ['boolean', null, true],
             ['boolean', null, false],
-            ['boolean', null, 'True'],
-            ['boolean', null, 'false'],
             ['number', null, 12],
-            ['number', null, '12'],
-            ['number', 'float', '12'],
-            ['number', 'double', '12'],
             ['number', null, 0.123],
-            ['number', null, '0.123'],
-            ['number', null, '-0.123'],
-            ['number', 'float', '-0.123'],
-            ['number', 'double', '-0.123'],
             ['integer', null, 12],
-            ['integer', null, '12'],
-            ['integer', null, '-12'],
         ];
     }
 
@@ -90,8 +79,16 @@ SPEC;
             ['object', 'not object'],
             ['array', ['a' => 1, 'b' => 2]], // this is not a plain array (a-la JSON)
             ['boolean', [1, 2]],
+            ['boolean', 'True'],
+            ['boolean', ''],
+            ['boolean', 0],
             ['number', []],
+            ['number', '12'],
+            ['number', '0.123'],
+            ['number', '-0.123'],
             ['integer', 12.55],
+            ['integer', '12'],
+            ['integer', '-12'],
             ['integer', new stdClass()],
             ['integer', 1.0],
         ];

--- a/tests/stubs/api.yaml
+++ b/tests/stubs/api.yaml
@@ -189,3 +189,47 @@ paths:
                 properties:
                   result:
                     type: string
+  /deserialize-headers:
+    get:
+      parameters:
+        - in: header
+          name: num
+          schema:
+            type: number
+        - in: header
+          name: bool
+          schema:
+            type: boolean
+        - in: header
+          name: int
+          schema:
+            type: integer
+      description: Get with numeric/bool header
+      responses:
+        200:
+          description: fake endpoint
+          content:
+            application/json:
+              schema: {}
+  /deserialize-cookies:
+    get:
+      description: Get with numeric/bool cookies
+      parameters:
+        - in: cookie
+          name: num
+          schema:
+            type: number
+        - in: cookie
+          name: bool
+          schema:
+            type: boolean
+        - in: cookie
+          name: int
+          schema:
+            type: integer
+      responses:
+        200:
+          description: fake endpoint
+          content:
+            application/json:
+              schema: {}

--- a/tests/stubs/form-url-encoded.yaml
+++ b/tests/stubs/form-url-encoded.yaml
@@ -32,3 +32,27 @@ paths:
       responses:
         204:
           description: good post
+  /urlencoded/scalar-deserialization:
+    post:
+      summary: Post form-url-encoded body
+      operationId: post-form-url-encoded-body-with-deserialization
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                secure:
+                  type: boolean
+                code:
+                  type: integer
+              required:
+                - id
+                - secure
+                - code
+
+      responses:
+        204:
+          description: good post

--- a/tests/stubs/multipart.yaml
+++ b/tests/stubs/multipart.yaml
@@ -116,6 +116,10 @@ paths:
                     description: This is a custom header
                     schema:
                       type: string
+                  X-Numeric-Header:
+                    description: This header must be numeric
+                    schema:
+                      type: number
       responses:
         204:
           description: good post

--- a/tests/stubs/multipart.yaml
+++ b/tests/stubs/multipart.yaml
@@ -123,3 +123,27 @@ paths:
       responses:
         204:
           description: good post
+  /multipart-deserialization:
+    post:
+      summary: Post multipart body
+      operationId: post-multipart-body-deserializtion
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - id
+                - secure
+                - code
+              properties:
+                id:            # Part 1 (numeric value)
+                  type: number
+                secure:        # Part 2 (bool value)
+                  type: boolean
+                code:          # Part 3 (int value)
+                  type: integer
+
+      responses:
+        204:
+          description: good post


### PR DESCRIPTION
Resolves #48 

Validation is now strict, but query, path and cookie params (that are always strings) attempted to convert to specified type.