### PR TITLE
Fix path parameters parsing like {id}.{format}

### DIFF
--- a/src/PSR7/OperationAddress.php
+++ b/src/PSR7/OperationAddress.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace League\OpenAPIValidation\PSR7;
 
 use League\OpenAPIValidation\PSR7\Exception\Validation\InvalidPath;
+use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
+use const PREG_SPLIT_DELIM_CAPTURE;
+use function implode;
 use function preg_match;
-use function preg_match_all;
+use function preg_quote;
 use function preg_replace;
+use function preg_split;
 use function sprintf;
-use function str_replace;
 use function strtok;
 
 class OperationAddress
@@ -76,13 +79,10 @@ class OperationAddress
         // 0. Filter URL, remove query string
         $url = strtok($url, '?');
 
-        // 1. Find param names
-        preg_match_all('#{([^}]+)}#', $this->path(), $m);
-        $parameterNames = $m[1];
+        // 1. Find param names and build pattern
+        $pattern = $this->buildPattern($this->path(), $parameterNames);
 
         // 2. Parse param values
-        $pattern = '#' . str_replace(['{', '}'], ['(?<', '>[^/]+)'], $this->path()) . '#';
-
         if (! preg_match($pattern, $url, $matches)) {
             throw InvalidPath::becausePathDoesNotMatchPattern($url, $this);
         }
@@ -94,5 +94,44 @@ class OperationAddress
         }
 
         return $parsedParams;
+    }
+
+    /**
+     * It builds PCRE pattern, which can be used to parse path. It also extract parameter names
+     *
+     * @param array<string>|null $parameterNames
+     */
+    protected function buildPattern(string $url, ?array &$parameterNames) : string
+    {
+        $parameterNames = [];
+        $pregParts      = [];
+        $inParameter    = false;
+
+        $parts = preg_split('#([{}])#', $url, -1, PREG_SPLIT_DELIM_CAPTURE);
+        foreach ($parts as $part) {
+            switch ($part) {
+                case '{':
+                    if ($inParameter) {
+                        throw InvalidSchema::becauseBracketsAreNotBalanced($url);
+                    }
+                    $inParameter = true;
+                    continue 2;
+                case '}':
+                    if (! $inParameter) {
+                        throw InvalidSchema::becauseBracketsAreNotBalanced($url);
+                    }
+                    $inParameter = false;
+                    continue 2;
+            }
+
+            if ($inParameter) {
+                $pregParts[]      = '(?<' . $part . '>[^/]+)';
+                $parameterNames[] = $part;
+            } else {
+                $pregParts[] = preg_quote($part, '#');
+            }
+        }
+
+        return '#' . implode($pregParts) . '#';
     }
 }

--- a/src/PSR7/OperationAddress.php
+++ b/src/PSR7/OperationAddress.php
@@ -112,13 +112,13 @@ class OperationAddress
             switch ($part) {
                 case '{':
                     if ($inParameter) {
-                        throw InvalidSchema::becauseBracketsAreNotBalanced($url);
+                        throw InvalidSchema::becauseBracesAreNotBalanced($url);
                     }
                     $inParameter = true;
                     continue 2;
                 case '}':
                     if (! $inParameter) {
-                        throw InvalidSchema::becauseBracketsAreNotBalanced($url);
+                        throw InvalidSchema::becauseBracesAreNotBalanced($url);
                     }
                     $inParameter = false;
                     continue 2;

--- a/src/Schema/Exception/InvalidSchema.php
+++ b/src/Schema/Exception/InvalidSchema.php
@@ -27,8 +27,8 @@ final class InvalidSchema extends RuntimeException
         return new static(sprintf("Type '%s' is unexpected.", $type));
     }
 
-    public static function becauseBracketsAreNotBalanced(string $path) : self
+    public static function becauseBracesAreNotBalanced(string $path) : self
     {
-        return new static(sprintf("Brackets in path '%s' are not balanced.", $path));
+        return new static(sprintf("Braces in path '%s' are not balanced.", $path));
     }
 }

--- a/src/Schema/Exception/InvalidSchema.php
+++ b/src/Schema/Exception/InvalidSchema.php
@@ -26,4 +26,9 @@ final class InvalidSchema extends RuntimeException
     {
         return new static(sprintf("Type '%s' is unexpected.", $type));
     }
+
+    public static function becauseBracketsAreNotBalanced(string $path) : self
+    {
+        return new static(sprintf("Brackets in path '%s' are not balanced.", $path));
+    }
 }

--- a/tests/PSR7/PathParametersTest.php
+++ b/tests/PSR7/PathParametersTest.php
@@ -69,4 +69,15 @@ final class PathParametersTest extends TestCase
         $validator->validate($request);
         $this->addToAssertionCount(1);
     }
+
+    public function testParsesFormat() : void
+    {
+        // dot in path template must be handled with care
+        $specFile = __DIR__ . '/../stubs/pathParams.yaml';
+        $request  = new ServerRequest('get', '/number/99.json');
+
+        $validator = (new ValidatorBuilder())->fromYamlFile($specFile)->getServerRequestValidator();
+        $validator->validate($request);
+        $this->addToAssertionCount(1);
+    }
 }

--- a/tests/Schema/PathParsingTest.php
+++ b/tests/Schema/PathParsingTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\OpenAPIValidation\Tests\Schema;
+
+use GuzzleHttp\Psr7\ServerRequest;
+use League\OpenAPIValidation\PSR7\ValidatorBuilder;
+use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
+use PHPUnit\Framework\TestCase;
+
+class PathParsingTest extends TestCase
+{
+    public function testInvalidPathParams() : void
+    {
+        // that specification doesn't raise any errors in swagger-editor
+        $yaml      = /** @lang yaml */
+            <<<YAML
+openapi: 3.0.0
+info:
+  title: Product import API
+  version: '1.0'
+servers:
+  - url: 'http://localhost:8000/api/v1'
+paths:
+  /test/{invalid{brackets}:
+    parameters: 
+      - name: 'invalid{brackets'
+        in: path
+        schema:
+          type: string
+        required: true
+    get:
+      responses:
+        '204':
+          description: no data
+YAML;
+        $validator = (new ValidatorBuilder())->fromYaml($yaml)->getServerRequestValidator();
+
+        $psrRequest = (new ServerRequest('get', 'http://localhost:8000/api/v1/test/whatever'));
+
+        $this->expectException(InvalidSchema::class);
+        $validator->validate($psrRequest);
+    }
+}

--- a/tests/stubs/pathParams.yaml
+++ b/tests/stubs/pathParams.yaml
@@ -61,3 +61,21 @@ paths:
       responses:
         204:
           description: No response
+  /number/{id}.{format}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+      - name: format
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Read data
+      operationId: read-int-format
+      responses:
+        204:
+          description: No response


### PR DESCRIPTION
OpenAPI paths like `/number/{id}.{format}` were converted to regex like `#/number/(?<id>[^/]+).(?<format>[^/]+)#` and due to unescaped dot it incorrectly parses string like `/number/1.json` to `['id' => '1.js', 'format' => 'n']`.

I have fixed such behavior with `preg_quote`. Also to distinguish parameter names from other parts braces balance is now validated. There is also test for it.