### PR TITLE
Tests, which use the *Of keyword in combination with references won't…

### DIFF
--- a/tests/Schema/SchemaValidatorTest.php
+++ b/tests/Schema/SchemaValidatorTest.php
@@ -24,6 +24,9 @@ abstract class SchemaValidatorTest extends TestCase
     {
         $spec = Reader::readFromYaml($rawSchema);
 
-        return new Schema($spec->schema);
+        $schema = new Schema($spec->schema);
+        $schema->resolveReferences(new ReferenceContext($spec, '/'));
+
+        return $schema;
     }
 }


### PR DESCRIPTION
… fail anymore.

League\OpenAPIValidation\Tests\Schema\SchemaValidatorTest::loadRawSchema() resolves the references exaclty like loadSchema() and the factories do.