### PR TITLE
Add anchors if pattern is constant and begins and ends with same letter.

### DIFF
--- a/src/Schema/Keywords/Pattern.php
+++ b/src/Schema/Keywords/Pattern.php
@@ -10,7 +10,7 @@ use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 use function preg_match;
 use function sprintf;
-use function strlen;
+use function str_replace;
 
 class Pattern extends BaseKeyword
 {
@@ -36,10 +36,7 @@ class Pattern extends BaseKeyword
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 
-        // add anchors
-        if ($pattern[0] !== $pattern[strlen($pattern) - 1]) {
-            $pattern = sprintf('#%s#', $pattern);
-        }
+        $pattern = sprintf('#%s#', str_replace('#', '\#', $pattern));
 
         if (! preg_match($pattern, $data)) {
             throw KeywordMismatch::fromKeyword('pattern', $data, sprintf('Data does not match pattern \'%s\'', $pattern));

--- a/tests/Schema/Keywords/PatternTest.php
+++ b/tests/Schema/Keywords/PatternTest.php
@@ -10,16 +10,33 @@ use League\OpenAPIValidation\Tests\Schema\SchemaValidatorTest;
 
 final class PatternTest extends SchemaValidatorTest
 {
-    public function testItValidatesPatternGreen() : void
+    /**
+     * @return array<array<string, string>>
+     */
+    public function validDataProvider() : array
+    {
+        return [
+            ['^[a|b]+$', 'abba'],
+            ['foo', 'foo'], // Tests adding anchors
+            ['foof', 'foof'], // Tests adding anchors when first and last character is same
+            ['1foo1', '1foo1'], // Tests adding anchors when first and last character is same with numbers
+            ['^#\d+$', '#123'], // Tests adding anchors to string which has #
+            ['^#(\d+)#$', '#123#'], // Tests adding anchors to string which has multiple#
+        ];
+    }
+
+    /**
+     * @dataProvider validDataProvider
+     */
+    public function testItValidatesPatternGreen(string $pattern, string $data) : void
     {
         $spec = <<<SPEC
 schema:
   type: string
-  pattern: "#^[a|b]+$#"
+  pattern: $pattern
 SPEC;
 
         $schema = $this->loadRawSchema($spec);
-        $data   = 'abba';
 
         (new SchemaValidator())->validate($data, $schema);
         $this->addToAssertionCount(1);
@@ -30,7 +47,7 @@ SPEC;
         $spec = <<<SPEC
 schema:
   type: string
-  pattern: "#^[a|b]+$#"
+  pattern: "^[a|b]+$"
 SPEC;
 
         $schema = $this->loadRawSchema($spec);

--- a/tests/stubs/complete.yaml
+++ b/tests/stubs/complete.yaml
@@ -29,7 +29,7 @@ paths:
         required: true
         schema:
           type: string
-          pattern: "#^[a-z]{4}$#"
+          pattern: "^[a-z]{4}$"
       - in: cookie
         name: session_id
         required: true


### PR DESCRIPTION
If I have a schema like this
```JSON
"format": {
  "pattern": "snakes",
  "type": "string"
}
```

anchors around `snakes` are not added. This PR fixes that.