### PR TITLE
Allow about:blank as uri

### DIFF
--- a/src/Schema/TypeFormats/StringURI.php
+++ b/src/Schema/TypeFormats/StringURI.php
@@ -11,6 +11,10 @@ class StringURI
 {
     public function __invoke(string $value) : bool
     {
+        if ($value === 'about:blank') {
+            return true;
+        }
+
         return filter_var($value, FILTER_VALIDATE_URL) !== false;
     }
 }

--- a/tests/Schema/TypeFormats/StringURITest.php
+++ b/tests/Schema/TypeFormats/StringURITest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\OpenAPIValidation\Tests\Schema\TypeFormats;
+
+use League\OpenAPIValidation\Schema\TypeFormats\StringURI;
+use PHPUnit\Framework\TestCase;
+
+class StringURITest extends TestCase
+{
+    /**
+     * @return array<array<string>>
+     */
+    public function greenURIDataProvider() : array
+    {
+        return [
+            ['http://example.com'],
+            ['about:blank'],
+        ];
+    }
+
+    /**
+     * @return array<array<string>>
+     */
+    public function redURIDataProvider() : array
+    {
+        return [
+            ['example.com'],
+            ['www.example.com'],
+        ];
+    }
+
+    /**
+     * @dataProvider greenURIDataProvider
+     */
+    public function testGreenURIFormat(string $uri) : void
+    {
+        $this->assertTrue((new StringURI())($uri));
+    }
+
+    /**
+     * @dataProvider redURIDataProvider
+     */
+    public function testRedURIFormat(string $uri) : void
+    {
+        $this->assertFalse((new StringURI())($uri));
+    }
+}


### PR DESCRIPTION
It is an edge case. But I think `about:blank` should also be a valid URI. For example, [this](https://tools.ietf.org/html/rfc7807#section-3.1) RFC uses `about:blank` as default value when no URI given.

I encountered this when I was working with Twitter's OpenAPI spec. They are implementing the `problems detail` RFC and make use of `about:blank` in their spec.