### PR TITLE
Infer object type if properties is set

### DIFF
--- a/src/Schema/SchemaValidator.php
+++ b/src/Schema/SchemaValidator.php
@@ -6,6 +6,7 @@ namespace League\OpenAPIValidation\Schema;
 
 use cebe\openapi\spec\Schema as CebeSchema;
 use cebe\openapi\spec\Type as CebeType;
+use League\OpenAPIValidation\Foundation\ArrayHelper;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\Keywords\AllOf;
 use League\OpenAPIValidation\Schema\Keywords\AnyOf;
@@ -127,7 +128,9 @@ final class SchemaValidator implements Validator
                 (new Items($schema, $this->validationStrategy, $breadCrumb))->validate($data, $schema->items);
             }
 
-            if ($schema->type === CebeType::OBJECT || (isset($schema->properties) && is_array($data))) {
+            if ($schema->type === CebeType::OBJECT
+                || (isset($schema->properties) && is_array($data) && ArrayHelper::isAssoc($data))
+            ) {
                 $additionalProperties = $schema->additionalProperties ?? null; // defaults to true
                 if ((isset($schema->properties) && count($schema->properties)) || $additionalProperties) {
                     (new Properties($schema, $this->validationStrategy, $breadCrumb))->validate(

--- a/src/Schema/SchemaValidator.php
+++ b/src/Schema/SchemaValidator.php
@@ -29,6 +29,7 @@ use League\OpenAPIValidation\Schema\Keywords\Required;
 use League\OpenAPIValidation\Schema\Keywords\Type;
 use League\OpenAPIValidation\Schema\Keywords\UniqueItems;
 use function count;
+use function is_array;
 
 // This will load a whole schema and data to validate if one matches another
 final class SchemaValidator implements Validator
@@ -126,7 +127,7 @@ final class SchemaValidator implements Validator
                 (new Items($schema, $this->validationStrategy, $breadCrumb))->validate($data, $schema->items);
             }
 
-            if ($schema->type === CebeType::OBJECT) {
+            if ($schema->type === CebeType::OBJECT || (isset($schema->properties) && is_array($data))) {
                 $additionalProperties = $schema->additionalProperties ?? null; // defaults to true
                 if ((isset($schema->properties) && count($schema->properties)) || $additionalProperties) {
                     (new Properties($schema, $this->validationStrategy, $breadCrumb))->validate(

--- a/tests/FromCommunity/Issue32Test.php
+++ b/tests/FromCommunity/Issue32Test.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\OpenAPIValidation\Tests\FromCommunity;
+
+use GuzzleHttp\Psr7\ServerRequest;
+use League\OpenAPIValidation\PSR7\Exception\ValidationFailed;
+use League\OpenAPIValidation\PSR7\ValidatorBuilder;
+use PHPUnit\Framework\TestCase;
+use function GuzzleHttp\Psr7\stream_for;
+use function json_encode;
+
+final class Issue32Test extends TestCase
+{
+    /**
+     * @see https://github.com/thephpleague/openapi-psr7-validator/issues/32
+     */
+    public function testIssue32() : void
+    {
+        $yaml = /** @lang yaml */
+            <<<'YAML'
+openapi: 3.0.0
+paths:
+  /api/test/create:
+    post:
+      description: 'Test'
+      operationId: api.prescription.create
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/prescription'
+      responses:
+        '200':
+          description: 'ok'
+components:
+  schemas:
+    prescription:
+      properties:
+        exampleTyp:
+          type: string
+          enum:
+            - VALID
+            - STILLVALID
+YAML;
+
+        $data = ['exampleTyp' => 'INVALID'];
+
+        $psrRequest = (new ServerRequest('post', 'http://localhost:8000/api/test/create'))
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody(stream_for(json_encode($data)));
+
+        $serverRequestValidator = (new ValidatorBuilder())->fromYaml($yaml)->getServerRequestValidator();
+
+        $this->expectException(ValidationFailed::class);
+        $serverRequestValidator->validate($psrRequest);
+    }
+}

--- a/tests/Schema/Keywords/PropertiesTest.php
+++ b/tests/Schema/Keywords/PropertiesTest.php
@@ -103,4 +103,21 @@ SPEC;
         $this->expectException(KeywordMismatch::class);
         (new SchemaValidator())->validate($data, $schema);
     }
+
+    public function testItInfersObjectTypeGreen() : void
+    {
+        $spec = <<<SPEC
+schema:
+  properties:
+    date:
+      type: string
+      format: date
+SPEC;
+
+        $schema = $this->loadRawSchema($spec);
+        $data   = ['date' => 'not-a-date'];
+
+        $this->expectException(KeywordMismatch::class);
+        (new SchemaValidator())->validate($data, $schema);
+    }
 }


### PR DESCRIPTION
Another possible edge case. Sometimes` type: object` might not be in the schema. This usually happens if `properties` is combined with `*Of` Some simple example is:

```JSON
{
  "oneOf": [
    {
      "type": "object",
      "properties": {
        "bar": {
          "type": "string"
        }
      }
    }
  ],
  "properties": {
    "foo": {
      "type": "string"
    }
  }
}
```

This schema should fail the validation for the following data:
```JSON
{
	"foo": 123
}
```

because `foo` is not a string.

This PR adds ability to guess the object type by checking if `properties` is set on the schema.