### PR TITLE
Use 1.1.3 as lowest version for respect/validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "psr/cache": "^1.0",
         "psr/http-message": "^1.0",
         "psr/http-server-middleware": "^1.0",
-        "respect/validation": "^1.1",
+        "respect/validation": "^1.1.3",
         "riverline/multipart-parser": "^2.0.3",
         "webmozart/assert": "^1.4"
     },


### PR DESCRIPTION
Versions lower than `1.1.3` of `respect/validation` does not support PHP 7.1 and above because of [this](https://github.com/Respect/Validation/issues/708) issue.

Since this library supports PHP 7.2 and above, it should depend on at least `1.1.3` for `respect/validation`

Using `--prefer-lowest` during `composer install` would install `1.1.0`. And that would cause issues while using this library.