### PR TITLE
Optional response header #73

### DIFF
--- a/src/PSR7/Validators/HeadersValidator.php
+++ b/src/PSR7/Validators/HeadersValidator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace League\OpenAPIValidation\PSR7\Validators;
 
-use GuzzleHttp\Psr7\Response;
 use League\OpenAPIValidation\PSR7\Exception\Validation\InvalidHeaders;
 use League\OpenAPIValidation\PSR7\MessageValidator;
 use League\OpenAPIValidation\PSR7\OperationAddress;
@@ -34,7 +33,7 @@ final class HeadersValidator implements MessageValidator
 
         // Check if message misses required headers
         foreach ($headerSpecs as $header => $spec) {
-            if (($message instanceof Response || $spec->required) && ! $message->hasHeader($header)) {
+            if ($spec->required && ! $message->hasHeader($header)) {
                 throw InvalidHeaders::becauseOfMissingRequiredHeader($header, $addr);
             }
 

--- a/tests/PSR7/ValidateResponseTest.php
+++ b/tests/PSR7/ValidateResponseTest.php
@@ -68,11 +68,11 @@ final class ValidateResponseTest extends BaseValidatorTest
     {
         $addr = new OperationAddress('/path1', 'get');
 
-        $response = $this->makeGoodResponse('/path1', 'get')->withHeader('Header-B', 'wrong value');
+        $response = $this->makeGoodResponse('/path1', 'get')->withHeader('Header-C', 'wrong value');
 
         $this->expectException(InvalidHeaders::class);
         $this->expectExceptionMessage(
-            'Value "wrong value" for header "Header-B" is invalid for Response [get /path1 200]'
+            'Value "wrong value" for header "Header-C" is invalid for Response [get /path1 200]'
         );
 
         $validator = (new ValidatorBuilder())->fromYamlFile($this->apiSpecFile)->getResponseValidator();

--- a/tests/stubs/api.yaml
+++ b/tests/stubs/api.yaml
@@ -89,6 +89,7 @@ paths:
           description: posted
           headers:
             Set-Cookie:
+              required: true
               schema:
                 type: string
           content:
@@ -106,6 +107,13 @@ paths:
           description: fake endpoint
           headers:
             Header-B:
+              required: true
+              schema:
+                type: string
+                enum:
+                  - good value
+                  - another good value
+            Header-C:
               schema:
                 type: string
                 enum:


### PR DESCRIPTION
Fix #73 

- [x] Update `tests/stubs/api.yaml` to set existing response headers to required
- [x] Add a new optional `Header-C` to operation `GET /path1`
- [x] Update `testItValidatesMessageWrongHeaderValueRed` to ensure optional headers are validated when provided