### PR TITLE
Discuss a misleading message: "Value expected to be 'array', 'array' given."

### DIFF
--- a/tests/Schema/Keywords/TypeTest.php
+++ b/tests/Schema/Keywords/TypeTest.php
@@ -20,6 +20,7 @@ final class TypeTest extends SchemaValidatorTest
             ['string', null, 'string value'],
             ['object', null, ['a' => 1]],
             ['array', null, ['a', 'b']],
+            ['array', null, ['0' => 'a', '2' => 'b']], // this triggers: "Value expected to be 'array', 'array' given."
             ['boolean', null, true],
             ['boolean', null, false],
             ['number', null, 12],
@@ -78,6 +79,7 @@ SPEC;
             ['string', 12],
             ['object', 'not object'],
             ['array', ['a' => 1, 'b' => 2]], // this is not a plain array (a-la JSON)
+            ['array', ['0' => 'a', '2' => 'b']], // this is not an array anymore
             ['boolean', [1, 2]],
             ['boolean', 'True'],
             ['boolean', ''],


### PR DESCRIPTION
Here is a problem found, see the diff.
The message is quite misleading, however it comes from the fact that "objects" and "arrays" in json are represented as just "arrays" in PHP... 
what do we do with this?