### PR TITLE
Adding Example Test Case for Issue #93

### DIFF
--- a/tests/FromCommunity/Issue93Test.php
+++ b/tests/FromCommunity/Issue93Test.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\OpenAPIValidation\Tests\FromCommunity;
+
+use GuzzleHttp\Psr7\Request;
+use League\OpenAPIValidation\PSR7\Exception\NoOperation;
+use League\OpenAPIValidation\PSR7\Exception\NoPath;
+use League\OpenAPIValidation\PSR7\ValidatorBuilder;
+use League\OpenAPIValidation\Tests\PSR7\BaseValidatorTest;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * @see https://github.com/thephpleague/openapi-psr7-validator/issues/79
+ */
+final class Issue93Test extends BaseValidatorTest
+{
+    protected function makeBadMethodRequest() : RequestInterface
+    {
+        return new Request('get', '/empty');
+    }
+
+    protected function makeBadPathRequest() : RequestInterface
+    {
+        return new Request('get', '/no-such-path');
+    }
+
+    public function testBadMethodRequest() : void
+    {
+        $request = $this->makeBadMethodRequest();
+
+        $this->expectException(NoOperation::class);
+        $this->expectExceptionMessage(
+            'OpenAPI spec contains no such operation [/empty,get]'
+        );
+
+        $validator = (new ValidatorBuilder())->fromYamlFile($this->apiSpecFile)->getRequestValidator();
+        $validator->validate($request);
+    }
+
+    public function testBadPathRequest() : void
+    {
+        $request = $this->makeBadPathRequest();
+
+        $this->expectException(NoPath::class);
+
+        $validator = (new ValidatorBuilder())->fromYamlFile($this->apiSpecFile)->getRequestValidator();
+        try {
+            $validator->validate($request);
+        } catch (NoPath $e) {
+            $this->assertEquals(
+                NoPath::class,
+                get_class($e)
+            );
+            throw $e;
+        }
+    }
+}


### PR DESCRIPTION
This is an example test case to reproduce the oddity noted in #93 where we have no ability to actually catch a `NoPath` Exception separately from a `NoOperation` Exception because both outcomes throw the latter.  This means one cannot bubble them separately as, e.g., a `404` and a `405` respectively.