### PR TITLE
PHP 8 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": ">=7.2",
         "ext-json": "*",
         "cebe/php-openapi": "^1.3",
-        "dflydev/fig-cookies": "^2.0",
+        "hansott/psr7-cookies": "^3.0.2",
         "league/uri": "^6.3",
         "psr/cache": "^1.0",
         "psr/http-message": "^1.0",
@@ -34,10 +34,10 @@
         "webmozart/assert": "^1.4"
     },
     "require-dev": {
-        "cache/array-adapter": "^1.0",
         "doctrine/coding-standard": "^8.0",
         "guzzlehttp/psr7": "^1.5",
-        "phpunit/phpunit": "^7|^8"
+        "phpunit/phpunit": "^7|^8|^9",
+        "symfony/cache": "^5.1"
     },
     "config": {
         "sort-packages": true

--- a/src/PSR7/Validators/CookiesValidator/RequestCookieValidator.php
+++ b/src/PSR7/Validators/CookiesValidator/RequestCookieValidator.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace League\OpenAPIValidation\PSR7\Validators\CookiesValidator;
 
 use cebe\openapi\spec\Parameter;
-use Dflydev\FigCookies\Cookie;
-use Dflydev\FigCookies\Cookies;
 use League\OpenAPIValidation\PSR7\Exception\Validation\InvalidCookies;
 use League\OpenAPIValidation\PSR7\MessageValidator;
 use League\OpenAPIValidation\PSR7\OperationAddress;
@@ -17,6 +15,10 @@ use League\OpenAPIValidation\Schema\SchemaValidator;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 use Webmozart\Assert\Assert;
+
+use function array_key_exists;
+use function explode;
+use function implode;
 
 class RequestCookieValidator implements MessageValidator
 {
@@ -39,42 +41,64 @@ class RequestCookieValidator implements MessageValidator
     public function validate(OperationAddress $addr, MessageInterface $message): void
     {
         Assert::isInstanceOf($message, RequestInterface::class);
-        $cookies = Cookies::fromRequest($message);
+        $cookies = $this->getCookiesFromMessage($message);
         $this->checkRequiredCookies($cookies, $addr);
         $this->checkCookiesAgainstSchema($message, $addr, $cookies);
     }
 
     /**
+     * @param string[] $cookies
+     *
      * @throws InvalidCookies
      */
-    private function checkRequiredCookies(Cookies $cookies, OperationAddress $addr): void
+    private function checkRequiredCookies(array $cookies, OperationAddress $addr): void
     {
         foreach ($this->specs as $cookieName => $spec) {
-            if ($spec->required && ! $cookies->has($cookieName)) {
+            if ($spec->required && ! array_key_exists($cookieName, $cookies)) {
                 throw InvalidCookies::becauseOfMissingRequiredCookie($cookieName, $addr);
             }
         }
     }
 
     /**
+     * @param string[] $cookies
+     *
      * @throws InvalidCookies
      */
-    private function checkCookiesAgainstSchema(RequestInterface $request, OperationAddress $addr, Cookies $cookies): void
+    private function checkCookiesAgainstSchema(RequestInterface $request, OperationAddress $addr, array $cookies): void
     {
         $validator = new SchemaValidator($this->detectValidationStrategy($request));
 
-        foreach ($cookies->getAll() as $cookie) {
-            /** @var Cookie $cookie */
-            if (! isset($this->specs[$cookie->getName()])) {
+        foreach ($cookies as $cookieName => $cookie) {
+            if (! isset($this->specs[$cookieName])) {
                 continue;
             }
 
-            $parameter = SerializedParameter::fromSpec($this->specs[$cookie->getName()]);
+            $parameter = SerializedParameter::fromSpec($this->specs[$cookieName]);
             try {
-                $validator->validate($parameter->deserialize($cookie->getValue()), $parameter->getSchema());
+                $validator->validate($parameter->deserialize($cookie), $parameter->getSchema());
             } catch (SchemaMismatch $e) {
-                throw InvalidCookies::becauseValueDoesNotMatchSchema($cookie->getName(), $cookie->getValue(), $addr, $e);
+                throw InvalidCookies::becauseValueDoesNotMatchSchema($cookieName, $cookie, $addr, $e);
             }
         }
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getCookiesFromMessage(MessageInterface $message): array
+    {
+        // Needed in case it is an array of cookies.
+        $cookieString  = implode('; ', $message->getHeader('Cookie'));
+        $headerCookies = explode('; ', $cookieString);
+
+        $cookies = [];
+        foreach ($headerCookies as $itm) {
+            $pairParts              = explode('=', $itm, 2);
+            $pairParts[1]           = $pairParts[1] ?? '';
+            $cookies[$pairParts[0]] = $pairParts[1];
+        }
+
+        return $cookies;
     }
 }

--- a/tests/PSR7/BaseValidatorTest.php
+++ b/tests/PSR7/BaseValidatorTest.php
@@ -4,14 +4,11 @@ declare(strict_types=1);
 
 namespace League\OpenAPIValidation\Tests\PSR7;
 
-use Dflydev\FigCookies\Cookie;
-use Dflydev\FigCookies\FigRequestCookies;
-use Dflydev\FigCookies\FigResponseCookies;
-use Dflydev\FigCookies\SetCookie;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\ServerRequest;
 use GuzzleHttp\Psr7\Uri;
+use HansOtt\PSR7Cookies\SetCookie;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
@@ -41,7 +38,7 @@ abstract class BaseValidatorTest extends TestCase
             case 'post /cookies':
                 $response = (new Response())
                     ->withHeader('Content-Type', 'text/plain');
-                $response = FigResponseCookies::set($response, SetCookie::create('session_id', 'abc'));
+                $response = SetCookie::thatStaysForever('session_id', 'abc')->addToResponse($response);
 
                 return $response;
 
@@ -98,8 +95,7 @@ abstract class BaseValidatorTest extends TestCase
 
             case 'post /cookies':
                 $request = $request->withHeader('Content-Type', 'text/plain');
-                $request = FigRequestCookies::set($request, Cookie::create('session_id', 'abc'));
-                $request = FigRequestCookies::set($request, Cookie::create('debug', '10'));
+                $request = $request->withHeader('Cookie', 'session_id=abc; debug=10');
 
                 return $request;
 

--- a/tests/PSR7/MessageCookiesTest.php
+++ b/tests/PSR7/MessageCookiesTest.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 namespace League\OpenAPIValidation\Tests\PSR7;
 
-use Dflydev\FigCookies\Cookie;
-use Dflydev\FigCookies\FigRequestCookies;
-use Dflydev\FigCookies\FigResponseCookies;
-use Dflydev\FigCookies\SetCookie;
+use HansOtt\PSR7Cookies\SetCookie;
 use League\OpenAPIValidation\PSR7\Exception\Validation\InvalidCookies;
 use League\OpenAPIValidation\PSR7\Exception\Validation\InvalidHeaders;
 use League\OpenAPIValidation\PSR7\OperationAddress;
@@ -100,8 +97,7 @@ final class MessageCookiesTest extends BaseValidatorTest
         $addr    = new OperationAddress('/cookies', 'post');
         $request = $this->makeGoodRequest($addr->path(), $addr->method())
                         ->withoutHeader('Cookie');
-        $request = FigRequestCookies::set($request, Cookie::create('session_id', 'goodvalue'));
-        $request = FigRequestCookies::set($request, Cookie::create('debug', 'bad value'));
+        $request = $request->withHeader('Cookie', 'session_id=goodvalue; debug=bad value');
 
         $this->expectException(InvalidCookies::class);
         $this->expectExceptionMessage('Value "bad value" for cookie "debug" is invalid for Request [post /cookies]');
@@ -129,7 +125,7 @@ final class MessageCookiesTest extends BaseValidatorTest
     {
         $addr    = new OperationAddress('/cookies', 'post');
         $request = $this->makeGoodRequest($addr->path(), $addr->method());
-        $request = FigRequestCookies::set($request, Cookie::create('extra', 'any value'));
+        $request = $request->withAddedHeader('Cookie', 'extra=any value');
 
         $validator = (new ValidatorBuilder())->fromYamlFile($this->apiSpecFile)->getRequestValidator();
         $validator->validate($request);
@@ -140,7 +136,7 @@ final class MessageCookiesTest extends BaseValidatorTest
     {
         $addr     = new ResponseAddress('/cookies', 'post', 200);
         $response = $this->makeGoodResponse($addr->path(), $addr->method());
-        $response = FigResponseCookies::set($response, SetCookie::create('any', 'value'));
+        $response = SetCookie::thatStaysForever('any', 'value')->addToResponse($response);
 
         $validator = (new ValidatorBuilder())->fromYamlFile($this->apiSpecFile)->getResponseValidator();
         $validator->validate($addr, $response);

--- a/tests/PSR7/ValidatorBuilderTest.php
+++ b/tests/PSR7/ValidatorBuilderTest.php
@@ -4,22 +4,20 @@ declare(strict_types=1);
 
 namespace League\OpenAPIValidation\Tests\PSR7;
 
-use Cache\Adapter\PHPArray\ArrayCachePool;
 use cebe\openapi\spec\OpenApi;
 use League\OpenAPIValidation\PSR7\CacheableSchemaFactory;
 use League\OpenAPIValidation\PSR7\ValidatorBuilder;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
- * @covers \OpenAPIValidation\PSR7\ValidatorBuilder
+ * @covers \League\OpenAPIValidation\PSR7\ValidatorBuilder
  */
 final class ValidatorBuilderTest extends TestCase
 {
     public function testItCachesParsedOpenApiSpec(): void
     {
-        // configure cache
-        $pool  = [];
-        $cache = new ArrayCachePool(10, $pool);
+        $cache = new ArrayAdapter(0, true, 0, 10);
 
         $factory = $this->createMock(CacheableSchemaFactory::class);
         $factory->expects($this->once())->method('createSchema')
@@ -37,9 +35,7 @@ final class ValidatorBuilderTest extends TestCase
 
     public function testItUtilizesCacheKeyOverride(): void
     {
-        // configure cache
-        $pool  = [];
-        $cache = new ArrayCachePool(10, $pool);
+        $cache = new ArrayAdapter(0, true, 0, 10);
 
         $factory = $this->createMock(CacheableSchemaFactory::class);
         $factory->expects($this->once())->method('createSchema')


### PR DESCRIPTION
This PR adds support for PHP 8 by removing `dflydev/fig-cookies` and replacing it with `hansott/psr7-cookies` and some custom code, and replaces `cache/array-adapter` with `symfony/cache`

Most of the changes are coming from style changes. So I made separate commits. [Here](https://github.com/thephpleague/openapi-psr7-validator/commit/a3bc3376953036e6f668149663eef9c44a10ad43) is the most relevant commit.

I think we don't need to wait for https://github.com/cebe/php-openapi/issues/81 to merge this. That library is already compatible with PHP8, only issues were in dev dependencies there.

Fixes #91 