### PR TITLE
Support for respect/validation v2.1 (php >=7.3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docs/
 .phpunit*
 composer.lock
 .phpcs*
+.vscode

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.3",
         "ext-json": "*",
         "cebe/php-openapi": "^1.3",
         "hansott/psr7-cookies": "^3.0.2",
@@ -29,7 +29,7 @@
         "psr/cache": "^1.0",
         "psr/http-message": "^1.0",
         "psr/http-server-middleware": "^1.0",
-        "respect/validation": "^1.1.3",
+        "respect/validation": "^2.1",
         "riverline/multipart-parser": "^2.0.3",
         "webmozart/assert": "^1.4"
     },

--- a/src/PSR7/Validators/SerializedParameter.php
+++ b/src/PSR7/Validators/SerializedParameter.php
@@ -12,7 +12,6 @@ use League\OpenAPIValidation\Schema\Exception\ContentTypeMismatch;
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\Exception\TypeMismatch;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function explode;
@@ -72,7 +71,7 @@ final class SerializedParameter
             }
 
             Validator::length(1, 1)->assert($content);
-        } catch (ExceptionInterface $e) {
+        } catch (\Respect\Validation\Exceptions\Exception $e) {
             // If there is a `schema`, `content` must be empty.
             // If there isn't a `schema`, a `content` with exactly 1 property must exist.
             // @see https://swagger.io/docs/specification/describing-parameters/#schema-vs-content

--- a/src/Schema/Keywords/AllOf.php
+++ b/src/Schema/Keywords/AllOf.php
@@ -9,7 +9,6 @@ use League\OpenAPIValidation\Schema\BreadCrumb;
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\SchemaValidator;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 final class AllOf extends BaseKeyword
@@ -46,7 +45,7 @@ final class AllOf extends BaseKeyword
         try {
             Validator::arrayVal()->assert($allOf);
             Validator::each(Validator::instance(CebeSchema::class))->assert($allOf);
-        } catch (ExceptionInterface $exception) {
+        } catch (\Respect\Validation\Exceptions\Exception $exception) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($exception);
         }
 

--- a/src/Schema/Keywords/AnyOf.php
+++ b/src/Schema/Keywords/AnyOf.php
@@ -11,7 +11,6 @@ use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
 use League\OpenAPIValidation\Schema\Exception\NotEnoughValidSchemas;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\SchemaValidator;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 class AnyOf extends BaseKeyword
@@ -48,7 +47,7 @@ class AnyOf extends BaseKeyword
         try {
             Validator::arrayVal()->assert($anyOf);
             Validator::each(Validator::instance(CebeSchema::class))->assert($anyOf);
-        } catch (ExceptionInterface $e) {
+        } catch (\Respect\Validation\Exceptions\Exception $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/Enum.php
+++ b/src/Schema/Keywords/Enum.php
@@ -6,7 +6,6 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function count;
@@ -33,7 +32,7 @@ class Enum extends BaseKeyword
         try {
             Validator::arrayType()->assert($enum);
             Validator::trueVal()->assert(count($enum) >= 1);
-        } catch (ExceptionInterface $e) {
+        } catch (\Respect\Validation\Exceptions\Exception $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/Items.php
+++ b/src/Schema/Keywords/Items.php
@@ -9,7 +9,6 @@ use League\OpenAPIValidation\Schema\BreadCrumb;
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\SchemaValidator;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function sprintf;
@@ -42,7 +41,7 @@ class Items extends BaseKeyword
         try {
             Validator::arrayVal()->assert($data);
             Validator::instance(CebeSchema::class)->assert($itemsSchema);
-        } catch (ExceptionInterface $e) {
+        } catch (\Respect\Validation\Exceptions\Exception $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/MaxItems.php
+++ b/src/Schema/Keywords/MaxItems.php
@@ -6,7 +6,6 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function count;
@@ -31,7 +30,7 @@ class MaxItems extends BaseKeyword
             Validator::arrayType()->assert($data);
             Validator::intVal()->assert($maxItems);
             Validator::trueVal()->assert($maxItems >= 0);
-        } catch (ExceptionInterface $e) {
+        } catch (\Respect\Validation\Exceptions\Exception $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/MaxLength.php
+++ b/src/Schema/Keywords/MaxLength.php
@@ -6,7 +6,6 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function mb_strlen;
@@ -36,7 +35,7 @@ class MaxLength extends BaseKeyword
             Validator::stringType()->assert($data);
             Validator::intType()->assert($maxLength);
             Validator::trueVal()->assert($maxLength >= 0);
-        } catch (ExceptionInterface $e) {
+        } catch (\Respect\Validation\Exceptions\Exception $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/MaxProperties.php
+++ b/src/Schema/Keywords/MaxProperties.php
@@ -6,7 +6,6 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function count;
@@ -30,7 +29,7 @@ class MaxProperties extends BaseKeyword
         try {
             Validator::arrayType()->assert($data);
             Validator::trueVal()->assert($maxProperties >= 0);
-        } catch (ExceptionInterface $e) {
+        } catch (\Respect\Validation\Exceptions\Exception $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/Maximum.php
+++ b/src/Schema/Keywords/Maximum.php
@@ -6,7 +6,6 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function sprintf;
@@ -39,9 +38,9 @@ class Maximum extends BaseKeyword
     public function validate($data, $maximum, bool $exclusiveMaximum = false): void
     {
         try {
-            Validator::numeric()->assert($data);
-            Validator::numeric()->assert($maximum);
-        } catch (ExceptionInterface $e) {
+            Validator::numericVal()->assert($data);
+            Validator::numericVal()->assert($maximum);
+        } catch (\Respect\Validation\Exceptions\Exception $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/MinItems.php
+++ b/src/Schema/Keywords/MinItems.php
@@ -6,7 +6,6 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function count;
@@ -34,7 +33,7 @@ class MinItems extends BaseKeyword
             Validator::arrayType()->assert($data);
             Validator::intVal()->assert($minItems);
             Validator::trueVal()->assert($minItems >= 0);
-        } catch (ExceptionInterface $e) {
+        } catch (\Respect\Validation\Exceptions\Exception $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/MinLength.php
+++ b/src/Schema/Keywords/MinLength.php
@@ -6,7 +6,6 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function mb_strlen;
@@ -38,7 +37,7 @@ class MinLength extends BaseKeyword
             Validator::stringType()->assert($data);
             Validator::intVal()->assert($minLength);
             Validator::trueVal()->assert($minLength >= 0);
-        } catch (ExceptionInterface $e) {
+        } catch (\Respect\Validation\Exceptions\Exception $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/MinProperties.php
+++ b/src/Schema/Keywords/MinProperties.php
@@ -6,7 +6,6 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function count;
@@ -33,7 +32,7 @@ class MinProperties extends BaseKeyword
         try {
             Validator::arrayType()->assert($data);
             Validator::trueVal()->assert($minProperties >= 0);
-        } catch (ExceptionInterface $e) {
+        } catch (\Respect\Validation\Exceptions\Exception $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/Minimum.php
+++ b/src/Schema/Keywords/Minimum.php
@@ -6,7 +6,6 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function sprintf;
@@ -39,9 +38,9 @@ class Minimum extends BaseKeyword
     public function validate($data, $minimum, bool $exclusiveMinimum = false): void
     {
         try {
-            Validator::numeric()->assert($data);
-            Validator::numeric()->assert($minimum);
-        } catch (ExceptionInterface $e) {
+            Validator::numericVal()->assert($data);
+            Validator::numericVal()->assert($minimum);
+        } catch (\Respect\Validation\Exceptions\Exception $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/MultipleOf.php
+++ b/src/Schema/Keywords/MultipleOf.php
@@ -6,7 +6,6 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function sprintf;
@@ -25,9 +24,9 @@ class MultipleOf extends BaseKeyword
     public function validate($data, $multipleOf): void
     {
         try {
-            Validator::numeric()->assert($data);
-            Validator::numeric()->positive()->assert($multipleOf);
-        } catch (ExceptionInterface $e) {
+            Validator::numericVal()->assert($data);
+            Validator::numericVal()->positive()->assert($multipleOf);
+        } catch (\Respect\Validation\Exceptions\Exception $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/Not.php
+++ b/src/Schema/Keywords/Not.php
@@ -10,7 +10,6 @@ use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\SchemaValidator;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 class Not extends BaseKeyword
@@ -42,7 +41,7 @@ class Not extends BaseKeyword
     {
         try {
             Validator::instance(CebeSchema::class)->assert($not);
-        } catch (ExceptionInterface $e) {
+        } catch (\Respect\Validation\Exceptions\Exception $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/OneOf.php
+++ b/src/Schema/Keywords/OneOf.php
@@ -12,7 +12,6 @@ use League\OpenAPIValidation\Schema\Exception\NotEnoughValidSchemas;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\Exception\TooManyValidSchemas;
 use League\OpenAPIValidation\Schema\SchemaValidator;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function count;
@@ -52,7 +51,7 @@ class OneOf extends BaseKeyword
         try {
             Validator::arrayVal()->assert($oneOf);
             Validator::each(Validator::instance(CebeSchema::class))->assert($oneOf);
-        } catch (ExceptionInterface $e) {
+        } catch (\Respect\Validation\Exceptions\Exception $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/Pattern.php
+++ b/src/Schema/Keywords/Pattern.php
@@ -6,7 +6,6 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function preg_match;
@@ -33,7 +32,7 @@ class Pattern extends BaseKeyword
         try {
             Validator::stringType()->assert($data);
             Validator::stringType()->assert($pattern);
-        } catch (ExceptionInterface $e) {
+        } catch (\Respect\Validation\Exceptions\Exception $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/Properties.php
+++ b/src/Schema/Keywords/Properties.php
@@ -10,7 +10,6 @@ use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\SchemaValidator;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function array_diff;
@@ -69,7 +68,7 @@ class Properties extends BaseKeyword
             Validator::arrayType()->assert($data);
             Validator::arrayVal()->assert($properties);
             Validator::each(Validator::instance(CebeSchema::class))->assert($properties);
-        } catch (ExceptionInterface $exception) {
+        } catch (\Respect\Validation\Exceptions\Exception $exception) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($exception);
         }
 

--- a/src/Schema/Keywords/Required.php
+++ b/src/Schema/Keywords/Required.php
@@ -9,7 +9,6 @@ use League\OpenAPIValidation\Schema\BreadCrumb;
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
 use League\OpenAPIValidation\Schema\SchemaValidator;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function array_unique;
@@ -53,7 +52,7 @@ class Required extends BaseKeyword
             Validator::arrayType()->assert($required);
             Validator::each(Validator::stringType())->assert($required);
             Validator::trueVal()->assert(count(array_unique($required)) === count($required));
-        } catch (ExceptionInterface $e) {
+        } catch (\Respect\Validation\Exceptions\Exception $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/UniqueItems.php
+++ b/src/Schema/Keywords/UniqueItems.php
@@ -6,7 +6,6 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function array_map;
@@ -38,7 +37,7 @@ class UniqueItems extends BaseKeyword
 
         try {
             Validator::arrayType()->assert($data);
-        } catch (ExceptionInterface $e) {
+        } catch (\Respect\Validation\Exceptions\Exception $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 


### PR DESCRIPTION
Hi,
As discussed in issue #102 I did some changes to support respect/validation v2.1.
This will require minimum php version 7.3, which I think is reasonalbe nowadays.
respect/validation 2 has a couple of backward incompatible changes so I had to change all the references to the ExceptionInterface interface with new ones.
I noticed that the cases where respect/validation may raise an exception are not fully tested in the test suite, so I send this pul request as is. The actual test suite has success on all tests.