### PR TITLE
Support Respect/Validation v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "psr/cache": "^1.0",
         "psr/http-message": "^1.0",
         "psr/http-server-middleware": "^1.0",
-        "respect/validation": "^1.1.3",
+        "respect/validation": "^1.1.3 || ^2.0",
         "riverline/multipart-parser": "^2.0.3",
         "webmozart/assert": "^1.4"
     },
@@ -40,7 +40,7 @@
         "phpstan/phpstan": "^0.12.59",
         "phpstan/phpstan-phpunit": "^0.12.16",
         "phpstan/phpstan-webmozart-assert": "^0.12.7",
-        "phpunit/phpunit": "^7|^8|^9",
+        "phpunit/phpunit": "^7 || ^8 || ^9",
         "symfony/cache": "^5.1"
     },
     "config": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,3 +9,5 @@ parameters:
     ignoreErrors:
         - '#Unsafe usage of new static\(\)\.#'
         - '#Method [a-zA-Z0-9_\\]+::[a-zA-Z0-9_]+\(\) should return cebe\\openapi\\spec\\OpenApi but returns cebe\\openapi\\SpecObjectInterface\.#'
+        - '#Caught class Respect\\Validation\\Exceptions\\ExceptionInterface not found.#'
+        - '#Call to an undefined static method Respect\\Validation\\Validator::numeric\(\).#'

--- a/src/PSR7/Validators/SerializedParameter.php
+++ b/src/PSR7/Validators/SerializedParameter.php
@@ -11,6 +11,7 @@ use League\OpenAPIValidation\Schema\Exception\ContentTypeMismatch;
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\Exception\TypeMismatch;
+use Respect\Validation\Exceptions\Exception;
 use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
@@ -71,7 +72,7 @@ final class SerializedParameter
             }
 
             Validator::length(1, 1)->assert($content);
-        } catch (ExceptionInterface $e) {
+        } catch (Exception | ExceptionInterface $e) {
             // If there is a `schema`, `content` must be empty.
             // If there isn't a `schema`, a `content` with exactly 1 property must exist.
             // @see https://swagger.io/docs/specification/describing-parameters/#schema-vs-content

--- a/src/Schema/Keywords/AllOf.php
+++ b/src/Schema/Keywords/AllOf.php
@@ -9,6 +9,7 @@ use League\OpenAPIValidation\Schema\BreadCrumb;
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\SchemaValidator;
+use Respect\Validation\Exceptions\Exception;
 use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
@@ -46,7 +47,7 @@ final class AllOf extends BaseKeyword
         try {
             Validator::arrayVal()->assert($allOf);
             Validator::each(Validator::instance(CebeSchema::class))->assert($allOf);
-        } catch (ExceptionInterface $exception) {
+        } catch (Exception | ExceptionInterface $exception) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($exception);
         }
 

--- a/src/Schema/Keywords/AnyOf.php
+++ b/src/Schema/Keywords/AnyOf.php
@@ -11,6 +11,7 @@ use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
 use League\OpenAPIValidation\Schema\Exception\NotEnoughValidSchemas;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\SchemaValidator;
+use Respect\Validation\Exceptions\Exception;
 use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
@@ -48,7 +49,7 @@ class AnyOf extends BaseKeyword
         try {
             Validator::arrayVal()->assert($anyOf);
             Validator::each(Validator::instance(CebeSchema::class))->assert($anyOf);
-        } catch (ExceptionInterface $e) {
+        } catch (Exception | ExceptionInterface $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/Enum.php
+++ b/src/Schema/Keywords/Enum.php
@@ -6,6 +6,7 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
+use Respect\Validation\Exceptions\Exception;
 use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
@@ -33,7 +34,7 @@ class Enum extends BaseKeyword
         try {
             Validator::arrayType()->assert($enum);
             Validator::trueVal()->assert(count($enum) >= 1);
-        } catch (ExceptionInterface $e) {
+        } catch (Exception | ExceptionInterface $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/Items.php
+++ b/src/Schema/Keywords/Items.php
@@ -9,6 +9,7 @@ use League\OpenAPIValidation\Schema\BreadCrumb;
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\SchemaValidator;
+use Respect\Validation\Exceptions\Exception;
 use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
@@ -42,7 +43,7 @@ class Items extends BaseKeyword
         try {
             Validator::arrayVal()->assert($data);
             Validator::instance(CebeSchema::class)->assert($itemsSchema);
-        } catch (ExceptionInterface $e) {
+        } catch (Exception | ExceptionInterface $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/MaxItems.php
+++ b/src/Schema/Keywords/MaxItems.php
@@ -6,6 +6,7 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
+use Respect\Validation\Exceptions\Exception;
 use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
@@ -31,7 +32,7 @@ class MaxItems extends BaseKeyword
             Validator::arrayType()->assert($data);
             Validator::intVal()->assert($maxItems);
             Validator::trueVal()->assert($maxItems >= 0);
-        } catch (ExceptionInterface $e) {
+        } catch (Exception | ExceptionInterface $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/MaxLength.php
+++ b/src/Schema/Keywords/MaxLength.php
@@ -6,6 +6,7 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
+use Respect\Validation\Exceptions\Exception;
 use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
@@ -36,7 +37,7 @@ class MaxLength extends BaseKeyword
             Validator::stringType()->assert($data);
             Validator::intType()->assert($maxLength);
             Validator::trueVal()->assert($maxLength >= 0);
-        } catch (ExceptionInterface $e) {
+        } catch (Exception | ExceptionInterface $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/MaxProperties.php
+++ b/src/Schema/Keywords/MaxProperties.php
@@ -6,6 +6,7 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
+use Respect\Validation\Exceptions\Exception;
 use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
@@ -30,7 +31,7 @@ class MaxProperties extends BaseKeyword
         try {
             Validator::arrayType()->assert($data);
             Validator::trueVal()->assert($maxProperties >= 0);
-        } catch (ExceptionInterface $e) {
+        } catch (Exception | ExceptionInterface $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/Maximum.php
+++ b/src/Schema/Keywords/Maximum.php
@@ -6,9 +6,12 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
+use Respect\Validation\Exceptions\Exception;
 use Respect\Validation\Exceptions\ExceptionInterface;
+use Respect\Validation\Rules\NumericVal;
 use Respect\Validation\Validator;
 
+use function class_exists;
 use function sprintf;
 
 class Maximum extends BaseKeyword
@@ -39,9 +42,14 @@ class Maximum extends BaseKeyword
     public function validate($data, $maximum, bool $exclusiveMaximum = false): void
     {
         try {
-            Validator::numeric()->assert($data);
-            Validator::numeric()->assert($maximum);
-        } catch (ExceptionInterface $e) {
+            if (class_exists(NumericVal::class)) {
+                Validator::numericVal()->assert($data);
+                Validator::numericVal()->positive()->assert($maximum);
+            } else {
+                Validator::numeric()->assert($data);
+                Validator::numeric()->positive()->assert($maximum);
+            }
+        } catch (Exception | ExceptionInterface $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/MinItems.php
+++ b/src/Schema/Keywords/MinItems.php
@@ -6,6 +6,7 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
+use Respect\Validation\Exceptions\Exception;
 use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
@@ -34,7 +35,7 @@ class MinItems extends BaseKeyword
             Validator::arrayType()->assert($data);
             Validator::intVal()->assert($minItems);
             Validator::trueVal()->assert($minItems >= 0);
-        } catch (ExceptionInterface $e) {
+        } catch (Exception | ExceptionInterface $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/MinLength.php
+++ b/src/Schema/Keywords/MinLength.php
@@ -6,6 +6,7 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
+use Respect\Validation\Exceptions\Exception;
 use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
@@ -38,7 +39,7 @@ class MinLength extends BaseKeyword
             Validator::stringType()->assert($data);
             Validator::intVal()->assert($minLength);
             Validator::trueVal()->assert($minLength >= 0);
-        } catch (ExceptionInterface $e) {
+        } catch (Exception | ExceptionInterface $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/MinProperties.php
+++ b/src/Schema/Keywords/MinProperties.php
@@ -6,6 +6,7 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
+use Respect\Validation\Exceptions\Exception;
 use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
@@ -33,7 +34,7 @@ class MinProperties extends BaseKeyword
         try {
             Validator::arrayType()->assert($data);
             Validator::trueVal()->assert($minProperties >= 0);
-        } catch (ExceptionInterface $e) {
+        } catch (Exception | ExceptionInterface $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/Minimum.php
+++ b/src/Schema/Keywords/Minimum.php
@@ -6,9 +6,12 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
+use Respect\Validation\Exceptions\Exception;
 use Respect\Validation\Exceptions\ExceptionInterface;
+use Respect\Validation\Rules\NumericVal;
 use Respect\Validation\Validator;
 
+use function class_exists;
 use function sprintf;
 
 class Minimum extends BaseKeyword
@@ -39,9 +42,14 @@ class Minimum extends BaseKeyword
     public function validate($data, $minimum, bool $exclusiveMinimum = false): void
     {
         try {
-            Validator::numeric()->assert($data);
-            Validator::numeric()->assert($minimum);
-        } catch (ExceptionInterface $e) {
+            if (class_exists(NumericVal::class)) {
+                Validator::numericVal()->assert($data);
+                Validator::numericVal()->positive()->assert($minimum);
+            } else {
+                Validator::numeric()->assert($data);
+                Validator::numeric()->positive()->assert($minimum);
+            }
+        } catch (Exception | ExceptionInterface $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/MultipleOf.php
+++ b/src/Schema/Keywords/MultipleOf.php
@@ -6,9 +6,12 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
+use Respect\Validation\Exceptions\Exception;
 use Respect\Validation\Exceptions\ExceptionInterface;
+use Respect\Validation\Rules\NumericVal;
 use Respect\Validation\Validator;
 
+use function class_exists;
 use function sprintf;
 
 class MultipleOf extends BaseKeyword
@@ -25,9 +28,14 @@ class MultipleOf extends BaseKeyword
     public function validate($data, $multipleOf): void
     {
         try {
-            Validator::numeric()->assert($data);
-            Validator::numeric()->positive()->assert($multipleOf);
-        } catch (ExceptionInterface $e) {
+            if (class_exists(NumericVal::class)) {
+                Validator::numericVal()->assert($data);
+                Validator::numericVal()->positive()->assert($multipleOf);
+            } else {
+                Validator::numeric()->assert($data);
+                Validator::numeric()->positive()->assert($multipleOf);
+            }
+        } catch (Exception | ExceptionInterface $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/Not.php
+++ b/src/Schema/Keywords/Not.php
@@ -10,6 +10,7 @@ use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\SchemaValidator;
+use Respect\Validation\Exceptions\Exception;
 use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
@@ -42,7 +43,7 @@ class Not extends BaseKeyword
     {
         try {
             Validator::instance(CebeSchema::class)->assert($not);
-        } catch (ExceptionInterface $e) {
+        } catch (Exception | ExceptionInterface $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/OneOf.php
+++ b/src/Schema/Keywords/OneOf.php
@@ -12,6 +12,7 @@ use League\OpenAPIValidation\Schema\Exception\NotEnoughValidSchemas;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\Exception\TooManyValidSchemas;
 use League\OpenAPIValidation\Schema\SchemaValidator;
+use Respect\Validation\Exceptions\Exception;
 use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
@@ -52,7 +53,7 @@ class OneOf extends BaseKeyword
         try {
             Validator::arrayVal()->assert($oneOf);
             Validator::each(Validator::instance(CebeSchema::class))->assert($oneOf);
-        } catch (ExceptionInterface $e) {
+        } catch (Exception | ExceptionInterface $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/Pattern.php
+++ b/src/Schema/Keywords/Pattern.php
@@ -6,6 +6,7 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
+use Respect\Validation\Exceptions\Exception;
 use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
@@ -33,7 +34,7 @@ class Pattern extends BaseKeyword
         try {
             Validator::stringType()->assert($data);
             Validator::stringType()->assert($pattern);
-        } catch (ExceptionInterface $e) {
+        } catch (Exception | ExceptionInterface $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/Properties.php
+++ b/src/Schema/Keywords/Properties.php
@@ -10,6 +10,7 @@ use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\SchemaValidator;
+use Respect\Validation\Exceptions\Exception;
 use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
@@ -69,7 +70,7 @@ class Properties extends BaseKeyword
             Validator::arrayType()->assert($data);
             Validator::arrayVal()->assert($properties);
             Validator::each(Validator::instance(CebeSchema::class))->assert($properties);
-        } catch (ExceptionInterface $exception) {
+        } catch (Exception | ExceptionInterface $exception) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($exception);
         }
 

--- a/src/Schema/Keywords/Required.php
+++ b/src/Schema/Keywords/Required.php
@@ -9,6 +9,7 @@ use League\OpenAPIValidation\Schema\BreadCrumb;
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
 use League\OpenAPIValidation\Schema\SchemaValidator;
+use Respect\Validation\Exceptions\Exception;
 use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
@@ -53,7 +54,7 @@ class Required extends BaseKeyword
             Validator::arrayType()->assert($required);
             Validator::each(Validator::stringType())->assert($required);
             Validator::trueVal()->assert(count(array_unique($required)) === count($required));
-        } catch (ExceptionInterface $e) {
+        } catch (Exception | ExceptionInterface $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/UniqueItems.php
+++ b/src/Schema/Keywords/UniqueItems.php
@@ -6,6 +6,7 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
+use Respect\Validation\Exceptions\Exception;
 use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
@@ -38,7 +39,7 @@ class UniqueItems extends BaseKeyword
 
         try {
             Validator::arrayType()->assert($data);
-        } catch (ExceptionInterface $e) {
+        } catch (Exception | ExceptionInterface $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 


### PR DESCRIPTION
Fixes #102 
Closes #103 (and based on these discussions)

Also completed `ignoreErrors` to phpstan.neon file since static analysis check is done with PHP 7.2 on GitHub CI.

This is the best thing we can do for the moment.
Adding a `DataValidator` [(see discussion)](https://github.com/thephpleague/openapi-psr7-validator/pull/103#discussion_r542231211) does not help since we loose a lot of things (auto-completion, static checks,...).
Possibly not the cleanest, but it supports v1 AND v2.
Plus we need to check with `class_exists` and not `method_exists`. These methods (numericVal,...) do not really exist, but use magic functions (__call, __callStatic).

One day, we could possibly think about dropping Respect/Validation v1 support (last release more than one year ago, 2019-05-28). Respect/Validation v2.0 supports PHP^7.2, while v2.1 supports PHP^7.3.