### PR TITLE
Remove 'positive' validation for `minimum` and `maximum` schema values

### DIFF
--- a/src/Schema/Keywords/Maximum.php
+++ b/src/Schema/Keywords/Maximum.php
@@ -44,10 +44,10 @@ class Maximum extends BaseKeyword
         try {
             if (class_exists(NumericVal::class)) {
                 Validator::numericVal()->assert($data);
-                Validator::numericVal()->positive()->assert($maximum);
+                Validator::numericVal()->assert($maximum);
             } else {
                 Validator::numeric()->assert($data);
-                Validator::numeric()->positive()->assert($maximum);
+                Validator::numeric()->assert($maximum);
             }
         } catch (Exception | ExceptionInterface $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);

--- a/src/Schema/Keywords/Minimum.php
+++ b/src/Schema/Keywords/Minimum.php
@@ -44,10 +44,10 @@ class Minimum extends BaseKeyword
         try {
             if (class_exists(NumericVal::class)) {
                 Validator::numericVal()->assert($data);
-                Validator::numericVal()->positive()->assert($minimum);
+                Validator::numericVal()->assert($minimum);
             } else {
                 Validator::numeric()->assert($data);
-                Validator::numeric()->positive()->assert($minimum);
+                Validator::numeric()->assert($minimum);
             }
         } catch (Exception | ExceptionInterface $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);

--- a/tests/Schema/Keywords/MaximumTest.php
+++ b/tests/Schema/Keywords/MaximumTest.php
@@ -10,16 +10,20 @@ use League\OpenAPIValidation\Tests\Schema\SchemaValidatorTest;
 
 final class MaximumTest extends SchemaValidatorTest
 {
-    public function testMaximumNonexclusiveKeywordGreen(): void
+    /**
+     * @testWith [100]
+     *           [0]
+     *           [-1]
+     */
+    public function testMaximumNonexclusiveKeywordGreen(int $data): void
     {
         $spec = <<<SPEC
 schema:
   type: number
-  maximum: 100
+  maximum: {$data}
 SPEC;
 
         $schema = $this->loadRawSchema($spec);
-        $data   = 100;
 
         (new SchemaValidator())->validate($data, $schema);
         $this->addToAssertionCount(1);

--- a/tests/Schema/Keywords/MinimumTest.php
+++ b/tests/Schema/Keywords/MinimumTest.php
@@ -10,16 +10,20 @@ use League\OpenAPIValidation\Tests\Schema\SchemaValidatorTest;
 
 final class MinimumTest extends SchemaValidatorTest
 {
-    public function testMinimumNonexclusiveKeywordGreen(): void
+    /**
+     * @testWith [100]
+     *           [0]
+     *           [-1]
+     */
+    public function testMinimumNonexclusiveKeywordGreen(int $data): void
     {
         $spec = <<<SPEC
 schema:
   type: number
-  minimum: 100
+  minimum: {$data}
 SPEC;
 
         $schema = $this->loadRawSchema($spec);
-        $data   = 100;
 
         (new SchemaValidator())->validate($data, $schema);
         $this->addToAssertionCount(1);


### PR DESCRIPTION
Will remove an unwanted validation introduced in https://github.com/thephpleague/openapi-psr7-validator/pull/112