### PR TITLE
`multipleOf` is not validating correctly for value `0.01`

### DIFF
--- a/tests/Schema/Keywords/MultipleOfTest.php
+++ b/tests/Schema/Keywords/MultipleOfTest.php
@@ -20,6 +20,9 @@ final class MultipleOfTest extends SchemaValidatorTest
             [10.0, 2],
             [10, .5],
             [9.9, .3],
+            [283, 0.01],
+            [283.6, 0.01],
+            [283.66, 0.01],
         ];
     }
 


### PR DESCRIPTION
Good afternoon :)

Thanks for your continued work on this useful library.

I have come across a small bug in my work today. The validator incorrectly throws `KeywordMismatch` within `MultipleOf::validate()` when given a data value of `283.66` and a multipleOf value of `0.01`. 0.01 *is* a multiple of 283.66, and according to JSON Schema, `multipleOf` can be any positive number.

At the moment, this PR is just a failing test, I haven't added a fix yet. I need to get my head around the fun of floating point maths in PHP :) But in the meantime, if you have any suggestions on how to address this, I'm happy to implement.