### PR TITLE
Indicate compatibility with psr/cache 2 and 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-json": "*",
         "cebe/php-openapi": "^1.3",
         "league/uri": "^6.3",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "psr/http-message": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "respect/validation": "^1.1.3 || ^2.0",


### PR DESCRIPTION
The PSR cache interfaces have been updated with type declarations. This library should be compatible right away, so let's update the composer.json file accordingly.