### PR TITLE
Prioritize full match paths in PathFinder

### DIFF
--- a/src/PSR7/OperationAddress.php
+++ b/src/PSR7/OperationAddress.php
@@ -19,6 +19,8 @@ use const PREG_SPLIT_DELIM_CAPTURE;
 
 class OperationAddress
 {
+    private const PATH_PLACEHOLDER = '#{[^}]+}#';
+
     /** @var string */
     protected $method;
     /** @var string */
@@ -38,7 +40,7 @@ class OperationAddress
      */
     public static function isPathMatchesSpec(string $specPath, string $path): bool
     {
-        $pattern = '#^' . preg_replace('#{[^}]+}#', '[^/]+', $specPath) . '/?$#';
+        $pattern = '#^' . preg_replace(self::PATH_PLACEHOLDER, '[^/]+', $specPath) . '/?$#';
 
         return (bool) preg_match($pattern, $path);
     }
@@ -56,6 +58,11 @@ class OperationAddress
     public function path(): string
     {
         return $this->path;
+    }
+
+    public function hasPlaceholders(): bool
+    {
+        return preg_match(self::PATH_PLACEHOLDER, $this->path()) === 1;
     }
 
     /**

--- a/tests/FromCommunity/RouteCollisionIssueTest.php
+++ b/tests/FromCommunity/RouteCollisionIssueTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\OpenAPIValidation\Tests\FromCommunity;
+
+use GuzzleHttp\Psr7\Response;
+use League\OpenAPIValidation\PSR7\OperationAddress;
+use League\OpenAPIValidation\PSR7\ValidatorBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class RouteCollisionIssueTest extends TestCase
+{
+    public function testRouteCollisionIsHandlerProperly(): void
+    {
+        $schema = /** @lang JSON */
+            '
+  {
+    "openapi": "3.0.0",
+    "info": {
+      "description": "",
+      "version": "1.0.0",
+      "title": "Apples"
+    },
+    "servers": [
+      {
+        "url": "/api"
+      }
+    ],
+    "paths": {
+      "/apples/{apple_id}": {
+        "get": {
+          "summary": "",
+          "description": "",
+          "operationId": "appleGet",
+          "parameters": [
+            {
+              "in": "path",
+              "name": "apple_id",
+              "schema": {
+                "type": "integer"
+              },
+              "required": true
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Success",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "required": [
+                      "apple"
+                    ],
+                    "properties": {
+                      "apple": {
+                        "$ref": "#/components/schemas/apple"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/apples/ready-to-eat": {
+        "get": {
+          "summary": "",
+          "description": "",
+          "operationId": "applesReadyGet",
+          "responses": {
+            "200": {
+              "description": "Success",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "properties": {
+                      "apples": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/apple"
+                        }
+                      }
+                    },
+                    "required": [
+                      "apples"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "components": {
+      "schemas": {
+        "apple": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    }
+  }
+';
+
+        $validator = (new ValidatorBuilder())->fromJson($schema)->getResponseValidator();
+        $operation = new OperationAddress('/api/apples/ready-to-eat', 'get');
+
+        $responseContent = /** @lang JSON */
+            '
+    {
+      "apples": [
+        {
+          "id": 0
+        }
+      ]
+    }
+';
+
+        $response = new Response(200, ['Content-Type' => 'application/json'], $responseContent);
+
+        $validator->validate($operation, $response);
+
+        $this->addToAssertionCount(1);
+    }
+}


### PR DESCRIPTION
Direct path matchig does not work in case of operation is prefixed with server URI. Since server URI could be declared on Operation there is more sence in processing the full matching cycle for all operations and the prioritize paths that do not contain placeholders over templated paths

Fixes #123 

cc @dmytro-demchyna