### PR TITLE
(#134) Add support for comma-separated list of encoding content types

### DIFF
--- a/src/PSR7/Validators/BodyValidator/MultipartValidator.php
+++ b/src/PSR7/Validators/BodyValidator/MultipartValidator.php
@@ -28,7 +28,7 @@ use Riverline\MultiPartParser\Converters\PSR7;
 use Riverline\MultiPartParser\StreamedPart;
 use RuntimeException;
 
-use function array_diff;
+use function array_diff_assoc;
 use function array_map;
 use function array_replace;
 use function array_shift;
@@ -245,14 +245,14 @@ class MultipartValidator implements MessageValidator
         }
 
         // Any expected parameter values must also match
-        return ! array_diff($expectedNormalized, $matchNormalized);
+        return ! array_diff_assoc($expectedNormalized, $matchNormalized);
     }
 
     /**
      * Per RFC-7231 Section 3.1.1.1:
      * "The type, subtype, and parameter name tokens are case-insensitive. Parameter values might or might not be case-sensitive..."
      *
-     * Section 3.1.1.2: "A charset is identified by a case-insensitive token."
+     * And section 3.1.1.2: "A charset is identified by a case-insensitive token."
      *
      * The following are equivalent:
      *

--- a/src/PSR7/Validators/BodyValidator/MultipartValidator.php
+++ b/src/PSR7/Validators/BodyValidator/MultipartValidator.php
@@ -28,7 +28,11 @@ use Riverline\MultiPartParser\Converters\PSR7;
 use Riverline\MultiPartParser\StreamedPart;
 use RuntimeException;
 
+use function array_diff;
+use function array_map;
 use function array_replace;
+use function array_shift;
+use function explode;
 use function in_array;
 use function is_array;
 use function json_decode;
@@ -38,6 +42,8 @@ use function preg_match;
 use function sprintf;
 use function str_replace;
 use function strpos;
+use function strtolower;
+use function substr;
 
 use const JSON_ERROR_NONE;
 
@@ -117,27 +123,20 @@ class MultipartValidator implements MessageValidator
 
             foreach ($parts as $part) {
                 // 2.1 parts encoding
-                $partContentType     = $part->getHeader(self::HEADER_CONTENT_TYPE);
-                $encodingContentType = $this->detectEncondingContentType($encoding, $part, $schema->properties[$partName]);
-                if (strpos($encodingContentType, '*') === false) {
-                    // strict comparison (ie "image/jpeg")
-                    if ($encodingContentType !== $partContentType) {
-                        throw InvalidBody::becauseBodyDoesNotMatchSchemaMultipart(
-                            $partName,
-                            $partContentType,
-                            $addr
-                        );
-                    }
-                } else {
-                    // loose comparison (ie "image/*")
-                    $encodingContentType = str_replace('*', '.*', $encodingContentType);
-                    if (! preg_match('#' . $encodingContentType . '#', $partContentType)) {
-                        throw InvalidBody::becauseBodyDoesNotMatchSchemaMultipart(
-                            $partName,
-                            $partContentType,
-                            $addr
-                        );
-                    }
+                $partContentType   = $part->getHeader(self::HEADER_CONTENT_TYPE);
+                $validContentTypes = $this->detectEncodingContentTypes($encoding, $part, $schema->properties[$partName]);
+                $match             = false;
+
+                foreach ($validContentTypes as $contentType) {
+                    $match = $match || $this->contentTypeMatches($contentType, $partContentType);
+                }
+
+                if (! $match) {
+                    throw InvalidBody::becauseBodyDoesNotMatchSchemaMultipart(
+                        $partName,
+                        $partContentType,
+                        $addr
+                    );
                 }
 
                 // 2.2. parts headers
@@ -195,7 +194,10 @@ class MultipartValidator implements MessageValidator
         return $multipartData;
     }
 
-    private function detectEncondingContentType(Encoding $encoding, StreamedPart $part, Schema $partSchema): string
+    /**
+     * @return string[]
+     */
+    private function detectEncodingContentTypes(Encoding $encoding, StreamedPart $part, Schema $partSchema): array
     {
         $contentType = $encoding->contentType;
 
@@ -219,7 +221,69 @@ class MultipartValidator implements MessageValidator
             }
         }
 
-        return $contentType;
+        return array_map('trim', explode(',', $contentType));
+    }
+
+    private function contentTypeMatches(string $expected, string $match): bool
+    {
+        $expectedNormalized = $this->normalizedContentTypeParts($expected);
+        $matchNormalized    = $this->normalizedContentTypeParts($match);
+        $expectedType       = array_shift($expectedNormalized);
+        $matchType          = array_shift($matchNormalized);
+
+        if (strpos($expectedType, '*') === false) {
+            // strict comparison (ie "image/jpeg")
+            if ($expectedType !== $matchType) {
+                return false;
+            }
+        } else {
+            // loose comparison (ie "image/*")
+            $expectedType = str_replace('*', '.*', $expectedType);
+            if (! preg_match('#' . $expectedType . '#', $matchType)) {
+                return false;
+            }
+        }
+
+        // Any expected parameter values must also match
+        return ! array_diff($expectedNormalized, $matchNormalized);
+    }
+
+    /**
+     * Per RFC-7231 Section 3.1.1.1:
+     * "The type, subtype, and parameter name tokens are case-insensitive. Parameter values might or might not be case-sensitive..."
+     *
+     * Section 3.1.1.2: "A charset is identified by a case-insensitive token."
+     *
+     * The following are equivalent:
+     *
+     * text/html;charset=utf-8
+     * text/html;charset=UTF-8
+     * Text/HTML;Charset="utf-8"
+     * text/html; charset="utf-8"
+     *
+     * @return array<int|string, string>
+     */
+    private function normalizedContentTypeParts(string $contentType): array
+    {
+        $parts  = array_map('trim', explode(';', $contentType));
+        $result = [strtolower(array_shift($parts))];
+
+        foreach ($parts as $part) {
+            [$parameter, $value] = explode('=', $part, 2);
+            $parameter           = strtolower($parameter);
+
+            if ($value[0] === '"') { // quoted-string
+                $value = str_replace('\\', '', substr($value, 1, -1));
+            }
+
+            if ($parameter === 'charset') {
+                $value = strtolower($value);
+            }
+
+            $result[$parameter] = $value;
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/PSR7/Validators/BodyValidator/MultipartValidatorTest.php
+++ b/tests/PSR7/Validators/BodyValidator/MultipartValidatorTest.php
@@ -141,7 +141,7 @@ Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryWfPNVh4wuWBlyE
 
 ------WebKitFormBoundaryWfPNVh4wuWBlyEyQ
 Content-Disposition: form-data; name="data"; filename="file1.txt"
-Content-Type: APPLICATION/XML; CHARSET=UTF-8; OTHER=value;
+Content-Type: APPLICATION/XML; CHARSET=UTF-8; OTHER=value
 
 [file content goes there]
 ------WebKitFormBoundaryWfPNVh4wuWBlyEyQ--

--- a/tests/PSR7/Validators/BodyValidator/MultipartValidatorTest.php
+++ b/tests/PSR7/Validators/BodyValidator/MultipartValidatorTest.php
@@ -141,7 +141,7 @@ Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryWfPNVh4wuWBlyE
 
 ------WebKitFormBoundaryWfPNVh4wuWBlyEyQ
 Content-Disposition: form-data; name="data"; filename="file1.txt"
-Content-Type: APPLICATION/XML;CHARSET=UTF-8
+Content-Type: APPLICATION/XML; CHARSET=UTF-8; OTHER=value;
 
 [file content goes there]
 ------WebKitFormBoundaryWfPNVh4wuWBlyEyQ--
@@ -271,7 +271,7 @@ Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryWfPNVh4wuWBlyE
 
 ------WebKitFormBoundaryWfPNVh4wuWBlyEyQ
 Content-Disposition: form-data; name="data"; filename="file1.txt"
-Content-Type: application/xml; charset=ISO-8859-1
+Content-Type: application/xml; other=utf-8; charset=ISO-8859-1
 
 [file content goes there]
 ------WebKitFormBoundaryWfPNVh4wuWBlyEyQ--

--- a/tests/PSR7/Validators/BodyValidator/MultipartValidatorTest.php
+++ b/tests/PSR7/Validators/BodyValidator/MultipartValidatorTest.php
@@ -132,6 +132,54 @@ Content-Type: image/whatever
 HTTP
 ,
             ],
+            // specified headers for one part (multiple, with charset)
+            [
+                <<<HTTP
+POST /multipart/encoding/multiple HTTP/1.1
+Content-Length: 2740
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+Content-Disposition: form-data; name="data"; filename="file1.txt"
+Content-Type: APPLICATION/XML;CHARSET=UTF-8
+
+[file content goes there]
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ--
+HTTP
+,
+            ],
+            // specified headers for one part (multiple, other valid type)
+            [
+                <<<HTTP
+POST /multipart/encoding/multiple HTTP/1.1
+Content-Length: 2740
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+Content-Disposition: form-data; name="data"; filename="file1.txt"
+Content-Type: application/json ; charset="ISO-8859-1"
+
+[file content goes there]
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ--
+HTTP
+,
+            ],
+            // specified headers for one part (multiple, wildcard)
+            [
+                <<<HTTP
+POST /multipart/encoding/multiple HTTP/1.1
+Content-Length: 2740
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+Content-Disposition: form-data; name="data"; filename="file1.txt"
+Content-Type: text/plain; charset=us-ascii
+
+[file content goes there]
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ--
+HTTP
+,
+            ],
             // deserialized values
             [
                 <<<HTTP
@@ -207,6 +255,40 @@ Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryWfPNVh4wuWBlyE
 ------WebKitFormBoundaryWfPNVh4wuWBlyEyQ
 Content-Disposition: form-data; name="image"; filename="file1.txt"
 Content-Type: invalid/type
+
+[file content goes there]
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ--
+HTTP
+,
+                InvalidBody::class,
+            ],
+            // wrong encoding charset for one of the parts (multiple)
+            [
+                <<<HTTP
+POST /multipart/encoding/multiple HTTP/1.1
+Content-Length: 2740
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+Content-Disposition: form-data; name="data"; filename="file1.txt"
+Content-Type: application/xml; charset=ISO-8859-1
+
+[file content goes there]
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ--
+HTTP
+,
+                InvalidBody::class,
+            ],
+            // missing encoding charset for one of the parts (multiple)
+            [
+                <<<HTTP
+POST /multipart/encoding/multiple HTTP/1.1
+Content-Length: 2740
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+Content-Disposition: form-data; name="data"; filename="file1.txt"
+Content-Type: application/xml
 
 [file content goes there]
 ------WebKitFormBoundaryWfPNVh4wuWBlyEyQ--

--- a/tests/stubs/multipart.yaml
+++ b/tests/stubs/multipart.yaml
@@ -76,6 +76,24 @@ paths:
       responses:
         204:
           description: good post
+  /multipart/encoding/multiple:
+    post:
+      summary: ---
+      operationId: post-multipart-encoding-multiple
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: string
+            encoding:
+              data:
+                contentType: application/xml; charset="utf-8", application/json, text/*
+      responses:
+        204:
+          description: good post
   /multipart/encoding/wildcard:
     post:
       summary: Post multipart body with wildcard encoding of one part


### PR DESCRIPTION
My proposal to fix #134, adding support for lists of valid encoding content types.

It should be relatively straightforward, and of course I'm open to whatever changes need to be made.