### PR TITLE
Fix string-to-boolean casting

### DIFF
--- a/src/PSR7/Validators/SerializedParameter.php
+++ b/src/PSR7/Validators/SerializedParameter.php
@@ -125,8 +125,13 @@ final class SerializedParameter
      */
     private function castToSchemaType($value, ?string $type)
     {
-        if (($type === CebeType::BOOLEAN) && is_scalar($value) && preg_match('#^(true|false)$#i', (string) $value)) {
-            return is_string($value) ? strtolower($value) === 'true' : (bool) $value;
+        if ($type === CebeType::BOOLEAN && is_scalar($value)) {
+            if (preg_match('#^(true|false)$#i', (string)$value)) {
+                return is_string($value) ? strtolower($value) === 'true' : (bool)$value;
+            }
+            if (preg_match('#^(0|1)$#i', (string)$value)) {
+                return (string)$value === '1';
+            }
         }
 
         if (

--- a/tests/PSR7/CookieDeserializeTest.php
+++ b/tests/PSR7/CookieDeserializeTest.php
@@ -13,13 +13,28 @@ use function sprintf;
 
 final class CookieDeserializeTest extends BaseValidatorTest
 {
-    public function testItDeserializesServerRequestCookieParametersGreen(): void
+    /**
+     * @return mixed[][]
+     */
+    public function dataProviderCookiesGreen(): array
+    {
+        return [
+            ['num' , '-1.2'],
+            ['int' , '414'],
+            ['bool', 'true'],
+            ['bool', '1'],
+            ['bool', '0'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderCookiesGreen
+     */
+    public function testItDeserializesServerRequestCookieParametersGreen(string $cookieName, string $cookieValue): void
     {
         $request = (new ServerRequest('get', new Uri('/deserialize-cookies')))
             ->withCookieParams([
-                'num' => '-1.2',
-                'int' => '414',
-                'bool' => 'true',
+                $cookieName => $cookieValue,
             ]);
 
         $validator = (new ValidatorBuilder())->fromYamlFile($this->apiSpecFile)->getServerRequestValidator();
@@ -37,7 +52,7 @@ final class CookieDeserializeTest extends BaseValidatorTest
             ['num', 'ac'],
             ['int', 'ac'],
             ['int', '1.0'],
-            ['bool', '1'],
+            ['bool', '2'],
             ['bool', 'yes'],
             ['bool', ''],
         ];

--- a/tests/PSR7/HeadersTest.php
+++ b/tests/PSR7/HeadersTest.php
@@ -22,12 +22,27 @@ final class HeadersTest extends BaseValidatorTest
         $this->addToAssertionCount(1);
     }
 
-    public function testItDeserializesRequestHeaderParametersGreen(): void
+    /**
+     * @return mixed[][]
+     */
+    public function dataProviderDeserializesRequestHeaderGreen(): array
+    {
+        return [
+            ['num', '-1.2'],
+            ['int', '414'],
+            ['bool', 'true'],
+            ['bool', '1'],
+            ['bool', '0'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderDeserializesRequestHeaderGreen
+     */
+    public function testItDeserializesRequestHeaderParametersGreen(string $headerName, string $headerValue): void
     {
         $request = (new ServerRequest('get', new Uri('/deserialize-headers')))
-            ->withHeader('num', '-1.2')
-            ->withHeader('int', '414')
-            ->withHeader('bool', 'true');
+            ->withHeader($headerName, $headerValue);
 
         $validator = (new ValidatorBuilder())->fromYamlFile($this->apiSpecFile)->getServerRequestValidator();
         $validator->validate($request);
@@ -44,7 +59,7 @@ final class HeadersTest extends BaseValidatorTest
             ['num', 'ac'],
             ['int', 'ac'],
             ['int', '1.0'],
-            ['bool', '1'],
+            ['bool', '2'],
             ['bool', 'yes'],
             ['bool', ''],
         ];

--- a/tests/PSR7/Validators/BodyValidator/MultipartValidatorTest.php
+++ b/tests/PSR7/Validators/BodyValidator/MultipartValidatorTest.php
@@ -267,7 +267,7 @@ Content-Type: text/plain
 Content-Disposition: form-data; name="secure"
 Content-Type: text/plain
 
-0
+2
 ------WebKitFormBoundaryOmz20xyMCkE27rN7
 Content-Disposition: form-data; name="code"
 Content-Type: text/plain


### PR DESCRIPTION
It is very common that boolean value casted to "0" or "1" values. And it is the industry-standard in PHP because it is how http_build_query() casts boolean. 
I faced with many such issues and have to disable validation or use artificial string in the specification when dealing with boolean flags in the GET parameters. 
So I create this small PR to fix this issue.