### PR TITLE
Strip query parameters from the URL before parsing path parameters

### DIFF
--- a/src/PSR7/OperationAddress.php
+++ b/src/PSR7/OperationAddress.php
@@ -89,7 +89,7 @@ class OperationAddress
         $url = strtok($url, '?');
 
         // 1. Find param names and build pattern
-        $pattern = $this->buildPattern($this->path(), $parameterNames);
+        $pattern = $this->buildPattern($url, $parameterNames);
 
         // 2. Parse param values
         if (! preg_match($pattern, $url, $matches)) {


### PR DESCRIPTION
The validator fails to parse the URLs with query parameters with the following error message:

```
Unable to parse {path-without-query-parameters} against the pattern {path-with-query-parameters} for Request [get {path-with-query-parameters}]
```

I am not sure whether this is a bug or a misuse of the library, but I could not find a way to resolve the issue from my code. You can see the [sample project](https://github.com/elnurvl/laravel-template) and run tests to see the failure. Let me know please, if there is anything wrong in my spec causing the issue or feel free to merge the PR if you agree this is a bug.