### PR TITLE
Prevent ErrorException when value is not iterable

### DIFF
--- a/src/PSR7/Validators/SerializedParameter.php
+++ b/src/PSR7/Validators/SerializedParameter.php
@@ -171,8 +171,8 @@ final class SerializedParameter
                 $value = explode(self::STYLE_DELIMITER_MAP[$this->style], $value);
             }
 
-            if (!is_array($value)) {
-                throw TypeMismatch::becauseTypeDoesNotMatch('array', $value);
+            if (!is_iterable($value)) {
+                throw TypeMismatch::becauseTypeDoesNotMatch('iterable', $value);
             }
 
             foreach ($value as &$val) {

--- a/src/PSR7/Validators/SerializedParameter.php
+++ b/src/PSR7/Validators/SerializedParameter.php
@@ -171,6 +171,10 @@ final class SerializedParameter
                 $value = explode(self::STYLE_DELIMITER_MAP[$this->style], $value);
             }
 
+            if (!is_array($value)) {
+                throw TypeMismatch::becauseTypeDoesNotMatch('array', $value);
+            }
+
             foreach ($value as &$val) {
                 $val = $this->castToSchemaType($val, $schema->items->type ?? null);
             }


### PR DESCRIPTION
Hello,

When `$value` is a string, an `ErrorException` is thrown with the following message:

```sh
foreach() argument must be of type array|object, string given
```

This PR prevents that exception by checking if `$value` is an array, as expected. 
