### PR TITLE
Fix missing ExceptionInterface

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,5 +5,4 @@ parameters:
         - tests
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
-        - '#Caught class Respect\\Validation\\Exceptions\\ExceptionInterface not found.#'
         - '#Call to an undefined static method Respect\\Validation\\Validator::numeric\(\).#'

--- a/src/PSR7/Validators/SerializedParameter.php
+++ b/src/PSR7/Validators/SerializedParameter.php
@@ -11,8 +11,6 @@ use League\OpenAPIValidation\Schema\Exception\ContentTypeMismatch;
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\Exception\TypeMismatch;
-use Respect\Validation\Exceptions\Exception;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function explode;
@@ -72,7 +70,7 @@ final class SerializedParameter
             }
 
             Validator::length(1, 1)->assert($content);
-        } catch (Exception | ExceptionInterface $e) {
+        } catch (\Throwable $e) {
             // If there is a `schema`, `content` must be empty.
             // If there isn't a `schema`, a `content` with exactly 1 property must exist.
             // @see https://swagger.io/docs/specification/describing-parameters/#schema-vs-content

--- a/src/Schema/Keywords/AllOf.php
+++ b/src/Schema/Keywords/AllOf.php
@@ -9,8 +9,6 @@ use League\OpenAPIValidation\Schema\BreadCrumb;
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\SchemaValidator;
-use Respect\Validation\Exceptions\Exception;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 final class AllOf extends BaseKeyword
@@ -47,7 +45,7 @@ final class AllOf extends BaseKeyword
         try {
             Validator::arrayVal()->assert($allOf);
             Validator::each(Validator::instance(CebeSchema::class))->assert($allOf);
-        } catch (Exception | ExceptionInterface $exception) {
+        } catch (\Throwable $exception) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($exception);
         }
 

--- a/src/Schema/Keywords/AnyOf.php
+++ b/src/Schema/Keywords/AnyOf.php
@@ -11,8 +11,6 @@ use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
 use League\OpenAPIValidation\Schema\Exception\NotEnoughValidSchemas;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\SchemaValidator;
-use Respect\Validation\Exceptions\Exception;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 class AnyOf extends BaseKeyword
@@ -49,7 +47,7 @@ class AnyOf extends BaseKeyword
         try {
             Validator::arrayVal()->assert($anyOf);
             Validator::each(Validator::instance(CebeSchema::class))->assert($anyOf);
-        } catch (Exception | ExceptionInterface $e) {
+        } catch (\Throwable $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/Enum.php
+++ b/src/Schema/Keywords/Enum.php
@@ -6,8 +6,6 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
-use Respect\Validation\Exceptions\Exception;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function count;
@@ -34,7 +32,7 @@ class Enum extends BaseKeyword
         try {
             Validator::arrayType()->assert($enum);
             Validator::trueVal()->assert(count($enum) >= 1);
-        } catch (Exception | ExceptionInterface $e) {
+        } catch (\Throwable $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/Items.php
+++ b/src/Schema/Keywords/Items.php
@@ -9,8 +9,6 @@ use League\OpenAPIValidation\Schema\BreadCrumb;
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\SchemaValidator;
-use Respect\Validation\Exceptions\Exception;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function sprintf;
@@ -43,7 +41,7 @@ class Items extends BaseKeyword
         try {
             Validator::arrayVal()->assert($data);
             Validator::instance(CebeSchema::class)->assert($itemsSchema);
-        } catch (Exception | ExceptionInterface $e) {
+        } catch (\Throwable $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/MaxItems.php
+++ b/src/Schema/Keywords/MaxItems.php
@@ -6,8 +6,6 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
-use Respect\Validation\Exceptions\Exception;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function count;
@@ -32,7 +30,7 @@ class MaxItems extends BaseKeyword
             Validator::arrayType()->assert($data);
             Validator::intVal()->assert($maxItems);
             Validator::trueVal()->assert($maxItems >= 0);
-        } catch (Exception | ExceptionInterface $e) {
+        } catch (\Throwable $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/MaxLength.php
+++ b/src/Schema/Keywords/MaxLength.php
@@ -6,8 +6,6 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
-use Respect\Validation\Exceptions\Exception;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function mb_strlen;
@@ -37,7 +35,7 @@ class MaxLength extends BaseKeyword
             Validator::stringType()->assert($data);
             Validator::intType()->assert($maxLength);
             Validator::trueVal()->assert($maxLength >= 0);
-        } catch (Exception | ExceptionInterface $e) {
+        } catch (\Throwable $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/MaxProperties.php
+++ b/src/Schema/Keywords/MaxProperties.php
@@ -6,8 +6,6 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
-use Respect\Validation\Exceptions\Exception;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function count;
@@ -31,7 +29,7 @@ class MaxProperties extends BaseKeyword
         try {
             Validator::arrayType()->assert($data);
             Validator::trueVal()->assert($maxProperties >= 0);
-        } catch (Exception | ExceptionInterface $e) {
+        } catch (\Throwable $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/Maximum.php
+++ b/src/Schema/Keywords/Maximum.php
@@ -6,8 +6,6 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
-use Respect\Validation\Exceptions\Exception;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Rules\NumericVal;
 use Respect\Validation\Validator;
 
@@ -49,7 +47,7 @@ class Maximum extends BaseKeyword
                 Validator::numeric()->assert($data);
                 Validator::numeric()->assert($maximum);
             }
-        } catch (Exception | ExceptionInterface $e) {
+        } catch (\Throwable $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/MinItems.php
+++ b/src/Schema/Keywords/MinItems.php
@@ -6,8 +6,6 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
-use Respect\Validation\Exceptions\Exception;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function count;
@@ -35,7 +33,7 @@ class MinItems extends BaseKeyword
             Validator::arrayType()->assert($data);
             Validator::intVal()->assert($minItems);
             Validator::trueVal()->assert($minItems >= 0);
-        } catch (Exception | ExceptionInterface $e) {
+        } catch (\Throwable $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/MinLength.php
+++ b/src/Schema/Keywords/MinLength.php
@@ -6,8 +6,6 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
-use Respect\Validation\Exceptions\Exception;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function mb_strlen;
@@ -39,7 +37,7 @@ class MinLength extends BaseKeyword
             Validator::stringType()->assert($data);
             Validator::intVal()->assert($minLength);
             Validator::trueVal()->assert($minLength >= 0);
-        } catch (Exception | ExceptionInterface $e) {
+        } catch (\Throwable $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/MinProperties.php
+++ b/src/Schema/Keywords/MinProperties.php
@@ -6,8 +6,6 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
-use Respect\Validation\Exceptions\Exception;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function count;
@@ -34,7 +32,7 @@ class MinProperties extends BaseKeyword
         try {
             Validator::arrayType()->assert($data);
             Validator::trueVal()->assert($minProperties >= 0);
-        } catch (Exception | ExceptionInterface $e) {
+        } catch (\Throwable $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/Minimum.php
+++ b/src/Schema/Keywords/Minimum.php
@@ -6,8 +6,6 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
-use Respect\Validation\Exceptions\Exception;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Rules\NumericVal;
 use Respect\Validation\Validator;
 
@@ -49,7 +47,7 @@ class Minimum extends BaseKeyword
                 Validator::numeric()->assert($data);
                 Validator::numeric()->assert($minimum);
             }
-        } catch (Exception | ExceptionInterface $e) {
+        } catch (\Throwable $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/MultipleOf.php
+++ b/src/Schema/Keywords/MultipleOf.php
@@ -6,8 +6,6 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
-use Respect\Validation\Exceptions\Exception;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Rules\NumericVal;
 use Respect\Validation\Validator;
 
@@ -35,7 +33,7 @@ class MultipleOf extends BaseKeyword
                 Validator::numeric()->assert($data);
                 Validator::numeric()->positive()->assert($multipleOf);
             }
-        } catch (Exception | ExceptionInterface $e) {
+        } catch (\Throwable $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/Not.php
+++ b/src/Schema/Keywords/Not.php
@@ -10,8 +10,6 @@ use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\SchemaValidator;
-use Respect\Validation\Exceptions\Exception;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 class Not extends BaseKeyword
@@ -43,7 +41,7 @@ class Not extends BaseKeyword
     {
         try {
             Validator::instance(CebeSchema::class)->assert($not);
-        } catch (Exception | ExceptionInterface $e) {
+        } catch (\Throwable $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/OneOf.php
+++ b/src/Schema/Keywords/OneOf.php
@@ -12,8 +12,6 @@ use League\OpenAPIValidation\Schema\Exception\NotEnoughValidSchemas;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\Exception\TooManyValidSchemas;
 use League\OpenAPIValidation\Schema\SchemaValidator;
-use Respect\Validation\Exceptions\Exception;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function count;
@@ -53,7 +51,7 @@ class OneOf extends BaseKeyword
         try {
             Validator::arrayVal()->assert($oneOf);
             Validator::each(Validator::instance(CebeSchema::class))->assert($oneOf);
-        } catch (Exception | ExceptionInterface $e) {
+        } catch (\Throwable $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/Pattern.php
+++ b/src/Schema/Keywords/Pattern.php
@@ -6,8 +6,6 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
-use Respect\Validation\Exceptions\Exception;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function preg_match;
@@ -34,7 +32,7 @@ class Pattern extends BaseKeyword
         try {
             Validator::stringType()->assert($data);
             Validator::stringType()->assert($pattern);
-        } catch (Exception | ExceptionInterface $e) {
+        } catch (\Throwable $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/Properties.php
+++ b/src/Schema/Keywords/Properties.php
@@ -10,8 +10,6 @@ use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
 use League\OpenAPIValidation\Schema\Exception\SchemaMismatch;
 use League\OpenAPIValidation\Schema\SchemaValidator;
-use Respect\Validation\Exceptions\Exception;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function array_diff;
@@ -70,7 +68,7 @@ class Properties extends BaseKeyword
             Validator::arrayType()->assert($data);
             Validator::arrayVal()->assert($properties);
             Validator::each(Validator::instance(CebeSchema::class))->assert($properties);
-        } catch (Exception | ExceptionInterface $exception) {
+        } catch (\Throwable $exception) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($exception);
         }
 

--- a/src/Schema/Keywords/Required.php
+++ b/src/Schema/Keywords/Required.php
@@ -9,8 +9,6 @@ use League\OpenAPIValidation\Schema\BreadCrumb;
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
 use League\OpenAPIValidation\Schema\SchemaValidator;
-use Respect\Validation\Exceptions\Exception;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function array_unique;
@@ -54,7 +52,7 @@ class Required extends BaseKeyword
             Validator::arrayType()->assert($required);
             Validator::each(Validator::stringType())->assert($required);
             Validator::trueVal()->assert(count(array_unique($required)) === count($required));
-        } catch (Exception | ExceptionInterface $e) {
+        } catch (\Throwable $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 

--- a/src/Schema/Keywords/UniqueItems.php
+++ b/src/Schema/Keywords/UniqueItems.php
@@ -6,8 +6,6 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
-use Respect\Validation\Exceptions\Exception;
-use Respect\Validation\Exceptions\ExceptionInterface;
 use Respect\Validation\Validator;
 
 use function array_map;
@@ -39,7 +37,7 @@ class UniqueItems extends BaseKeyword
 
         try {
             Validator::arrayType()->assert($data);
-        } catch (Exception | ExceptionInterface $e) {
+        } catch (\Throwable $e) {
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 


### PR DESCRIPTION
Hi,

`\Respect\Validation\Exceptions\ExceptionInterface` does not exist anymore, and `Respect\Validation\Exceptions\Exception` extends from `\Throwable` without adding any additional value.

This PR removes the unexisting interface usage and simplifies exception catching. 

