### PR TITLE
Access operation security element directly, avoiding getSerializableData

### DIFF
--- a/src/PSR7/SpecFinder.php
+++ b/src/PSR7/SpecFinder.php
@@ -23,9 +23,9 @@ use League\OpenAPIValidation\PSR7\Exception\NoResponseCode;
 use League\OpenAPIValidation\Schema\Exception\InvalidSchema;
 use Webmozart\Assert\Assert;
 
+use function is_array;
 use function json_decode;
 use function json_encode;
-use function property_exists;
 use function substr;
 
 final class SpecFinder
@@ -152,15 +152,15 @@ final class SpecFinder
         $opSpec = $this->findOperationSpec($addr);
 
         // 1. Collect security params
-        if (property_exists($opSpec->getSerializableData(), 'security')) {
-            // security is set on operation level
-            $securitySpecs = $opSpec->security;
-        } else {
-            // security is set on root level (fallback option)
-            $securitySpecs = $this->openApi->security;
+        $securitySpecs = $opSpec->security;
+
+        // security is set on operation level
+        if (is_array($securitySpecs)) {
+            return $securitySpecs;
         }
 
-        return $securitySpecs;
+        // security is set on root level (fallback option)
+        return $this->openApi->security;
     }
 
     /**


### PR DESCRIPTION
With a relatively full-featured spec, `SpecFinder::findSecuritySpecs()` is pretty slow because of the call to `getSerializableData`. However, it's not necessary to serialize the `Operation` element to see if `security` is defined, as the property can be accessed directly and the getter will do the right thing.