### PR TITLE
Ensure additionalProperty uses correct schema.

### DIFF
--- a/src/Schema/Keywords/Properties.php
+++ b/src/Schema/Keywords/Properties.php
@@ -108,7 +108,7 @@ class Properties extends BaseKeyword
             // if not covered by "properties"
             $schemaValidator->validate(
                 $data[$propName],
-                $additionalProperties,
+                $additionalProperties->properties[$propName],
                 $this->dataBreadCrumb->addCrumb($propName)
             );
         }


### PR DESCRIPTION
I encountered this issue when attempting to validate data against this schema:

```yaml
EnvironmentFlags:
      type: object
      description: An array of various flags that indicate functionality associated with the environment.
      additionalProperties:
        type: object
        properties:
          cde:
            type: boolean
            description: Determines if the environment is on-demand.
```

The `Properties::validate()` method currently attempts to validate `additionalProperties` by their parent definition which results in an error which validating valid data.