### PR TITLE
Handle path parameters for arrays correctly

### DIFF
--- a/tests/PSR7/PathParametersTest.php
+++ b/tests/PSR7/PathParametersTest.php
@@ -80,4 +80,59 @@ final class PathParametersTest extends TestCase
         $validator->validate($request);
         $this->addToAssertionCount(1);
     }
+
+    public function testItValidatesPathParameterArray(): void
+    {
+        // dot in path template must be handled with care
+        $specFile = __DIR__ . '/../stubs/pathParams.yaml';
+        $request  = new ServerRequest('get', '/array/1,2,3,99');
+
+        $validator = (new ValidatorBuilder())->fromYamlFile($specFile)->getServerRequestValidator();
+        $validator->validate($request);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testItValidatesPathParameterSimpleArray(): void
+    {
+        // dot in path template must be handled with care
+        $specFile = __DIR__ . '/../stubs/pathParams.yaml';
+        $request  = new ServerRequest('get', '/arrayLabel/.1,2,3,99');
+
+        $validator = (new ValidatorBuilder())->fromYamlFile($specFile)->getServerRequestValidator();
+        $validator->validate($request);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testItValidatesPathParameterExplodedSimpleArray(): void
+    {
+        // dot in path template must be handled with care
+        $specFile = __DIR__ . '/../stubs/pathParams.yaml';
+        $request  = new ServerRequest('get', '/arrayLabelExploded/.1.2.3.99');
+
+        $validator = (new ValidatorBuilder())->fromYamlFile($specFile)->getServerRequestValidator();
+        $validator->validate($request);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testItValidatesPathParameterMatrixArray(): void
+    {
+        // dot in path template must be handled with care
+        $specFile = __DIR__ . '/../stubs/pathParams.yaml';
+        $request  = new ServerRequest('get', '/arrayMatrix/;id=1,2,3,99');
+
+        $validator = (new ValidatorBuilder())->fromYamlFile($specFile)->getServerRequestValidator();
+        $validator->validate($request);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testItValidatesPathParameterExplodedMatrixArray(): void
+    {
+        // dot in path template must be handled with care
+        $specFile = __DIR__ . '/../stubs/pathParams.yaml';
+        $request  = new ServerRequest('get', '/arrayMatrixExploded/;id=1;id=2;id=3;id=99');
+
+        $validator = (new ValidatorBuilder())->fromYamlFile($specFile)->getServerRequestValidator();
+        $validator->validate($request);
+        $this->addToAssertionCount(1);
+    }
 }

--- a/tests/stubs/pathParams.yaml
+++ b/tests/stubs/pathParams.yaml
@@ -79,3 +79,84 @@ paths:
       responses:
         204:
           description: No response
+  /array/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: array
+          items:
+            type: integer
+    get:
+      summary: Read data
+      operationId: read-array-int
+      responses:
+        204:
+          description: No reponse
+  /arrayLabel/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        style: label
+        schema:
+          type: array
+          items:
+            type: integer
+    get:
+      summary: Read data
+      operationId: read-array-int-label
+      responses:
+        204:
+          description: No reponse
+  /arrayLabelExploded/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        style: label
+        explode: true
+        schema:
+          type: array
+          items:
+            type: integer
+    get:
+      summary: Read data
+      operationId: read-array-int-label-explode
+      responses:
+        204:
+          description: No reponse
+  /arrayMatrix/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        style: matrix
+        schema:
+          type: array
+          items:
+            type: integer
+    get:
+      summary: Read data
+      operationId: read-array-int-matrix
+      responses:
+        204:
+          description: No reponse
+  /arrayMatrixExploded/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        style: matrix
+        explode: true
+        schema:
+          type: array
+          items:
+            type: integer
+    get:
+      summary: Read data
+      operationId: read-array-int-matrix
+      responses:
+        204:
+          description: No reponse


### PR DESCRIPTION
The parameters for serialized arrays was using the same deserialization check.
There are different formats for header, query and path. Split up the validation of arrays into two different sets to allow different validation for path and header/query parameters.

The changes will validate path parameters for arrays but not objects which is still not working.



Because of objects within path parameter is probably the most unused things in the specs these have been left out intentionally.