### PR TITLE
Allow specifying encoding for optional parts of multipart data

### DIFF
--- a/src/PSR7/Validators/BodyValidator/MultipartValidator.php
+++ b/src/PSR7/Validators/BodyValidator/MultipartValidator.php
@@ -26,7 +26,6 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UploadedFileInterface;
 use Riverline\MultiPartParser\Converters\PSR7;
 use Riverline\MultiPartParser\StreamedPart;
-use RuntimeException;
 
 use function array_replace;
 use function in_array;
@@ -35,7 +34,6 @@ use function json_decode;
 use function json_last_error;
 use function json_last_error_msg;
 use function preg_match;
-use function sprintf;
 use function str_replace;
 use function strpos;
 
@@ -247,7 +245,7 @@ class MultipartValidator implements MessageValidator
 
         foreach ($encodings as $partName => $encoding) {
             if (! isset($body[$partName])) {
-                throw new RuntimeException(sprintf('Specified body part %s is not found', $partName));
+                continue;
             }
 
             $part = $body[$partName];

--- a/src/PSR7/Validators/BodyValidator/MultipartValidator.php
+++ b/src/PSR7/Validators/BodyValidator/MultipartValidator.php
@@ -108,12 +108,6 @@ class MultipartValidator implements MessageValidator
 
         foreach ($encodings as $partName => $encoding) {
             $parts = $document->getPartsByName($partName); // multiple parts share a name?
-            if (! $parts) {
-                throw new RuntimeException(sprintf(
-                    'Specified body part %s is not found',
-                    $partName
-                ));
-            }
 
             foreach ($parts as $part) {
                 // 2.1 parts encoding

--- a/tests/PSR7/Validators/BodyValidator/MultipartValidatorTest.php
+++ b/tests/PSR7/Validators/BodyValidator/MultipartValidatorTest.php
@@ -214,6 +214,23 @@ HTTP
 ,
                 InvalidBody::class,
             ],
+            // missing required part
+            [
+                <<<HTTP
+POST /multipart/encoding HTTP/1.1
+Content-Length: 428
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryOmz20xyMCkE27rN7
+
+------WebKitFormBoundaryOmz20xyMCkE27rN7
+Content-Disposition: form-data; name="description"
+Content-Type: text/plain
+
+123
+------WebKitFormBoundaryOmz20xyMCkE27rN7--
+HTTP
+,
+                InvalidBody::class,
+            ],
             // wrong header for one part
             [
                 <<<HTTP

--- a/tests/PSR7/Validators/BodyValidator/MultipartValidatorTest.php
+++ b/tests/PSR7/Validators/BodyValidator/MultipartValidatorTest.php
@@ -11,6 +11,7 @@ use League\OpenAPIValidation\PSR7\Exception\Validation\InvalidBody;
 use League\OpenAPIValidation\PSR7\Exception\Validation\InvalidHeaders;
 use League\OpenAPIValidation\PSR7\ValidatorBuilder;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\UploadedFileInterface;
 
 use function filesize;
 use function GuzzleHttp\Psr7\parse_request;
@@ -339,25 +340,56 @@ HTTP
         $validator->validate($serverRequest);
     }
 
-    public function testValidateMultipartServerRequestGreen(): void
+    /**
+     * @return mixed[][]
+     */
+    public function dataProviderMultipartServerRequestGreen(): array
     {
-        $specFile = __DIR__ . '/../../../stubs/multipart.yaml';
-
         $imagePath = __DIR__ . '/../../../stubs/image.jpg';
         $imageSize = filesize($imagePath);
 
-        $serverRequest = (new ServerRequest('post', new Uri('/multipart')))
-            ->withHeader('Content-Type', 'multipart/form-data')
-            ->withParsedBody([
-                'id'      => 'bc8e1430-a963-11e9-a2a3-2a2ae2dbcce4',
-                'address' => [
-                    'street' => 'Some street',
-                    'city'   => 'some city',
+        return [
+            // Normal multipart message
+            [
+                'post',
+                '/multipart',
+                [
+                    'id'      => 'bc8e1430-a963-11e9-a2a3-2a2ae2dbcce4',
+                    'address' => [
+                        'street' => 'Some street',
+                        'city'   => 'some city',
+                    ],
                 ],
-            ])
-            ->withUploadedFiles([
-                'profileImage' => new UploadedFile($imagePath, $imageSize, 0),
-            ]);
+                [
+                    'profileImage' => new UploadedFile($imagePath, $imageSize, 0),
+                ],
+            ],
+            // Missing optional field with defined encoding
+            [
+                'post',
+                '/multipart/encoding',
+                [],
+                [
+                    'image' => new UploadedFile($imagePath, $imageSize, 0),
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param string[]                             $body
+     * @param array<string, UploadedFileInterface> $files
+     *
+     * @dataProvider dataProviderMultipartServerRequestGreen
+     */
+    public function testValidateMultipartServerRequestGreen(string $method, string $uri, array $body = [], array $files = []): void
+    {
+        $specFile = __DIR__ . '/../../../stubs/multipart.yaml';
+
+        $serverRequest = (new ServerRequest($method, new Uri($uri)))
+            ->withHeader('Content-Type', 'multipart/form-data')
+            ->withParsedBody($body)
+            ->withUploadedFiles($files);
 
         $validator = (new ValidatorBuilder())->fromYamlFile($specFile)->getServerRequestValidator();
         $validator->validate($serverRequest);

--- a/tests/stubs/multipart.yaml
+++ b/tests/stubs/multipart.yaml
@@ -66,13 +66,19 @@ paths:
           multipart/form-data:
             schema:
               type: object
+              required:
+                - image
               properties:
                 image:
                   type: string
                   format: binary
+                description:
+                  type: string
             encoding:
               image:
                 contentType: specific/type
+              description:
+                contentType: text/plain
       responses:
         204:
           description: good post


### PR DESCRIPTION
Currently, any part of multipart data with an `encoding` provided in the spec will throw a validation error if it's not present in the body. As far as I know, providing an `encoding` value is not supposed to imply `required` for the part, so I've simply removed the check throwing an exception if a part doesn't exist when checking for a valid encoding.

I've expanded the test spec for this case and for good measure, I've added a test showing that the schema validation takes place, though I think other multipart tests probably do cover that.

@lezhnev74 Do you know if I'm missing something on this?