### PR TITLE
Use epsilon to compare floating points

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": ">=7.2",
-        "ext-bcmath": "*",
         "ext-json": "*",
         "devizzent/cebe-php-openapi": "^1.0",
         "league/uri": "^6.3",

--- a/src/Schema/Keywords/MultipleOf.php
+++ b/src/Schema/Keywords/MultipleOf.php
@@ -10,12 +10,13 @@ use Respect\Validation\Rules\NumericVal;
 use Respect\Validation\Validator;
 use Throwable;
 
-use function bcdiv;
 use function class_exists;
 use function sprintf;
 
 class MultipleOf extends BaseKeyword
 {
+    private const EPSILON = 0.00000001;
+
     /**
      * The value of "multipleOf" MUST be a number, strictly greater than 0.
      * A numeric instance is only valid if division by this keyword's value results in an integer.
@@ -39,9 +40,9 @@ class MultipleOf extends BaseKeyword
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 
-        $value = (float) bcdiv((string) $data, (string) $multipleOf, 1);
-        if ($value - (int) $value !== 0.0) {
-            throw KeywordMismatch::fromKeyword('multipleOf', $data, sprintf('Division by %d did not resulted in integer', $multipleOf));
+        $value = round($data / $multipleOf, 8);
+        if ($value - (int) $value > self::EPSILON) {
+            throw KeywordMismatch::fromKeyword('multipleOf', $data, sprintf('Division by %s did not resulted in integer', $multipleOf));
         }
     }
 }

--- a/src/Schema/Keywords/MultipleOf.php
+++ b/src/Schema/Keywords/MultipleOf.php
@@ -11,6 +11,7 @@ use Respect\Validation\Validator;
 use Throwable;
 
 use function class_exists;
+use function round;
 use function sprintf;
 
 class MultipleOf extends BaseKeyword

--- a/tests/Schema/Keywords/MultipleOfTest.php
+++ b/tests/Schema/Keywords/MultipleOfTest.php
@@ -21,6 +21,7 @@ final class MultipleOfTest extends SchemaValidatorTest
             [10, .5],
             [9.9, .3],
             [.94, .01],
+            [1, .3333333333],
         ];
     }
 
@@ -35,6 +36,7 @@ final class MultipleOfTest extends SchemaValidatorTest
             [10, .11],
             [9.9, .451],
             [.94, .03],
+            [1, .3333333],
         ];
     }
 

--- a/tests/Schema/Keywords/MultipleOfTest.php
+++ b/tests/Schema/Keywords/MultipleOfTest.php
@@ -21,7 +21,6 @@ final class MultipleOfTest extends SchemaValidatorTest
             [10, .5],
             [9.9, .3],
             [.94, .01],
-            [1, .3333333333],
         ];
     }
 


### PR DESCRIPTION
This is a alternative to https://github.com/thephpleague/openapi-psr7-validator/pull/171 that doesn't require everyone to install bcmath to keep using this library.

Precision of 8 should be "close enough" to consider it equal. That's one 10 millionth of a fraction off... which is an incredibly small amount. `1 / 3 = 0.33333333` therefore `1 / 0.33333333 = 3` because it is "close enough."

Issue #172