### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg)
 
 # OpenAPI PSR-7 Message (HTTP Request/Response) Validator
-This package can validate PSR-7 messages against OpenAPI <=3.1.x specifications 
+This package can validate PSR-7 messages against OpenAPI 3.0.x and 3.1.0 specifications 
 expressed in YAML or JSON. 
 
 ![](image.jpg)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg)
 
 # OpenAPI PSR-7 Message (HTTP Request/Response) Validator
-This package can validate PSR-7 messages against OpenAPI (3.0.x) specifications 
+This package can validate PSR-7 messages against OpenAPI <=3.1.x specifications 
 expressed in YAML or JSON. 
 
 ![](image.jpg)


### PR DESCRIPTION
Given this PR has been merged, I think 3.1.x is supported now? The readme still said 3.0.x

https://github.com/thephpleague/openapi-psr7-validator/issues/163
https://github.com/thephpleague/openapi-psr7-validator/pull/185