### PR TITLE
Change array merging

### DIFF
--- a/src/PSR7/Validators/BodyValidator/MultipartValidator.php
+++ b/src/PSR7/Validators/BodyValidator/MultipartValidator.php
@@ -28,7 +28,7 @@ use Riverline\MultiPartParser\Converters\PSR7;
 use Riverline\MultiPartParser\StreamedPart;
 use RuntimeException;
 
-use function array_replace;
+use function array_merge_recursive;
 use function in_array;
 use function is_array;
 use function json_decode;
@@ -235,7 +235,7 @@ class MultipartValidator implements MessageValidator
 
         $files = $this->normalizeFiles($message->getUploadedFiles());
 
-        $body = array_replace($body, $files);
+        $body = array_merge_recursive($body, $files);
 
         $validator = new SchemaValidator($this->detectValidationStrategy($message));
         try {


### PR DESCRIPTION
Before, in multipart validation, the validator lost the text part with the request data. So all validations failed if I have a file and request data, for example as json.