### PR TITLE
Pass Schema class to format validator

### DIFF
--- a/src/Schema/Keywords/Type.php
+++ b/src/Schema/Keywords/Type.php
@@ -128,7 +128,7 @@ class Type extends BaseKeyword
             $formatValidator = new $formatValidator();
         }
 
-        if (! $formatValidator($data)) {
+        if (! $formatValidator($data, $this->parentSchema)) {
             throw FormatMismatch::fromFormat($format, $data, $matchedType);
         }
     }


### PR DESCRIPTION
Hi guys
Great library!

I *really really really* hope this gets merged (or feedback given), I see many open PRs here collecting dust ;-/. Can we maybe be of assistance in maintaining this library?

Anyway, this PR fulfills a need we have: The `format` validators need more context, they need to know the full schema of the property it is applied to. The OpenAPI standard allows for additional fields in the schema that are prefixed with `x-*`. We use those fields for additional metadata.

An example would be the `file` format that would allow for a `x-mime-type` additional attribute - then this fictional format validator could do a mime detection and refuse the binary blob if the mime type is now in the additional attribute. 

Thanks for feedback/merge

**UPDATE** Locally the phpunit suite was green, it seems there was an error setting up the tests in Scrutinizer. I seem to be unable to restart the task :cry: 
