### PR TITLE
Fix HeadersValidator for parameters with content

### DIFF
--- a/src/PSR7/Validators/HeadersValidator.php
+++ b/src/PSR7/Validators/HeadersValidator.php
@@ -41,7 +41,7 @@ final class HeadersValidator implements MessageValidator
 
             foreach ($message->getHeader($header) as $headerValue) {
                 try {
-                    $validator->validate($parameter->deserialize($headerValue), $spec->schema);
+                    $validator->validate($parameter->deserialize($headerValue), $parameter->getSchema());
                 } catch (SchemaMismatch $exception) {
                     throw InvalidHeaders::becauseValueDoesNotMatchSchema($header, $headerValue, $addr, $exception);
                 }


### PR DESCRIPTION
Headers can also have `content` instead of `schema` the same as other parameters ([see OpenAPI Specification here](https://swagger.io/docs/specification/describing-parameters/)).
This is handled correctly in other parameters but seems to have gotten missing in the `HeadersValidator`. For example see the `ArrayValidator` [[link](https://github.com/thephpleague/openapi-psr7-validator/blob/master/src/PSR7/Validators/ArrayValidator.php#L57)], which uses the same code line as I updated the `HeaderValidator` to.

Without this change it causes an exception:
```
TypeError: League\OpenAPIValidation\Schema\SchemaValidator::validate(): Argument #2 ($schema) must be of type cebe\openapi\spec\Schema, null given, called in ***/vendor/league/openapi-psr7-validator/src/PSR7/Validators/HeadersValidator.php on line 44
```