### PR TITLE
Allow null as standalone type

### DIFF
--- a/src/Schema/Keywords/Nullable.php
+++ b/src/Schema/Keywords/Nullable.php
@@ -27,6 +27,10 @@ class Nullable extends BaseKeyword
 
     public function nullableByType(): bool
     {
-        return ! is_string($this->parentSchema->type) && in_array('null', $this->parentSchema->type);
+        if (is_string($this->parentSchema->type)) {
+            return $this->parentSchema->type === 'null';
+        }
+
+        return in_array('null', $this->parentSchema->type);
     }
 }

--- a/tests/Schema/Keywords/NullableTest.php
+++ b/tests/Schema/Keywords/NullableTest.php
@@ -25,6 +25,20 @@ SPEC;
         $this->addToAssertionCount(1);
     }
 
+    public function testItValidatesNullableStandaloneGreen(): void
+    {
+        $spec = <<<SPEC
+schema:
+    type: 'null'
+SPEC;
+
+        $schema = $this->loadRawSchema($spec);
+        $data   = null;
+
+        (new SchemaValidator())->validate($data, $schema);
+        $this->addToAssertionCount(1);
+    }
+
     public function testItValidatesNullableRed(): void
     {
         $spec = <<<SPEC


### PR DESCRIPTION
The validator throws an exception with the following (API enforces that only one of the fields is filled):

Data passed:
```php
[
    'department_id' => null,
    'team_id' => 1,
]
```

Schema:
```yaml
- oneOf:
    - type: object
      properties:
        department_id:
          type: integer
        team_id:
          type: 'null'
      required:
        - department_id
    - type: object
      properties:
        department_id:
          type: 'null'
        team_id:
          type: integer
      required:
        - team_id
```

With the proposed change the validator would not throw an exception any more.