### PR TITLE
Fix `nullable`: `false` validation

### DIFF
--- a/src/Schema/Keywords/Nullable.php
+++ b/src/Schema/Keywords/Nullable.php
@@ -7,7 +7,7 @@ namespace League\OpenAPIValidation\Schema\Keywords;
 use League\OpenAPIValidation\Schema\Exception\KeywordMismatch;
 
 use function in_array;
-use function is_string;
+use function is_array;
 
 class Nullable extends BaseKeyword
 {
@@ -27,6 +27,6 @@ class Nullable extends BaseKeyword
 
     public function nullableByType(): bool
     {
-        return ! is_string($this->parentSchema->type) && in_array('null', $this->parentSchema->type);
+        return is_array($this->parentSchema->type) && in_array('null', $this->parentSchema->type);
     }
 }

--- a/tests/FromCommunity/IssueNullablePropertyTest.php
+++ b/tests/FromCommunity/IssueNullablePropertyTest.php
@@ -70,9 +70,7 @@ JSON;
             'POST',
             'headers:/api/data',
             ['Content-Type' => 'application/json'],
-            json_encode(
-                ['value' => null],
-            )
+            json_encode(['value' => null])
         );
 
         $this->expectException(InvalidBody::class);

--- a/tests/FromCommunity/IssueNullablePropertyTest.php
+++ b/tests/FromCommunity/IssueNullablePropertyTest.php
@@ -15,51 +15,52 @@ final class IssueNullablePropertyTest extends BaseValidatorTest
 {
     public function testNullableFalseThrowInvalidBody(): void
     {
-        $json = <<<JSON
-            {
-              "openapi": "3.0.0",
-              "paths": {
-                "/api/data": {
-                  "post": {
-                    "requestBody": {
-                      "required": true,
-                      "content": {
-                        "application/json": {
-                          "schema": {
-                            "type": "object",
-                            "required": [
-                              "value"
-                            ],
-                            "properties": {
-                              "value": {
-                                "nullable": false,
-                                "oneOf": [
-                                  {"type": "string"},
-                                  {"type": "boolean"}
-                                ]
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "responses": {
-                      "200": {
-                        "description": "A response",
-                        "content": {
-                          "application/json": {
-                            "schema": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      }
-                    }
+        $json = /** @lang json */
+        <<<JSON
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/api/data": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "value"
+                ],
+                "properties": {
+                  "value": {
+                    "nullable": false,
+                    "oneOf": [
+                      {"type": "string"},
+                      {"type": "boolean"}
+                    ]
                   }
                 }
               }
             }
-        JSON;
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "A response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+JSON;
 
         $requestValidator = (new ValidatorBuilder())
             ->fromJson($json)

--- a/tests/FromCommunity/IssueNullablePropertyTest.php
+++ b/tests/FromCommunity/IssueNullablePropertyTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\OpenAPIValidation\Tests\FromCommunity;
+
+use GuzzleHttp\Psr7\Request;
+use League\OpenAPIValidation\PSR7\Exception\Validation\InvalidBody;
+use League\OpenAPIValidation\PSR7\ValidatorBuilder;
+use League\OpenAPIValidation\Tests\PSR7\BaseValidatorTest;
+
+use function json_encode;
+
+final class IssueNullablePropertyTest extends BaseValidatorTest
+{
+    public function testNullableFalseThrowInvalidBody(): void
+    {
+        $json = <<<JSON
+            {
+              "openapi": "3.0.0",
+              "paths": {
+                "/api/data": {
+                  "post": {
+                    "requestBody": {
+                      "required": true,
+                      "content": {
+                        "application/json": {
+                          "schema": {
+                            "type": "object",
+                            "required": [
+                              "value"
+                            ],
+                            "properties": {
+                              "value": {
+                                "nullable": false,
+                                "oneOf": [
+                                  {"type": "string"},
+                                  {"type": "boolean"}
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "responses": {
+                      "200": {
+                        "description": "A response",
+                        "content": {
+                          "application/json": {
+                            "schema": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        JSON;
+
+        $requestValidator = (new ValidatorBuilder())
+            ->fromJson($json)
+            ->getRequestValidator();
+
+        $request = new Request(
+            'POST',
+            'headers:/api/data',
+            ['Content-Type' => 'application/json'],
+            json_encode(
+                ['value' => null],
+            )
+        );
+
+        $this->expectException(InvalidBody::class);
+
+        $requestValidator->validate($request);
+    }
+}


### PR DESCRIPTION
## Context

(See this issue https://github.com/thephpleague/openapi-psr7-validator/issues/227)

For some reason `nullable` is implicitly `true` (see https://github.com/thephpleague/openapi-psr7-validator/pull/155/files#r1587568801)

But trying to validate an explicitly`"nullable": false` property will crash with a `TypeError` instead of throwing an `InvalidBody` `Exception`.

## Modification

- checking if the `$this->parentSchema->type` is a proper `array` instead of checking if it is not a `string`
- adding a non-regression test