### PR TITLE
Updated library league/uri

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.2 || ^8.1",
         "ext-json": "*",
         "devizzent/cebe-php-openapi": "^1.0",
         "league/uri": "^7.4",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": ">=7.2",
         "ext-json": "*",
         "devizzent/cebe-php-openapi": "^1.0",
-        "league/uri": "^6.3 || ^7.0",
+        "league/uri": "7.4.1",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "psr/http-message": "^1.0 || ^2.0",
         "psr/http-server-middleware": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": ">=7.2",
         "ext-json": "*",
         "devizzent/cebe-php-openapi": "^1.0",
-        "league/uri": "7.4.1",
+        "league/uri": "^7.4",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "psr/http-message": "^1.0 || ^2.0",
         "psr/http-server-middleware": "^1.0",


### PR DESCRIPTION
Current constraint on library version `"league/uri": "^6.3 || ^7.0"`, make not possible to install the most recent library `league/uri-interfaces ^7.4`, that is required in some important packages, as the amphp/http-client.