### PR TITLE
Feat: make the keyword compliant with OpenApi 3.1

### DIFF
--- a/src/Schema/Keywords/Items.php
+++ b/src/Schema/Keywords/Items.php
@@ -12,6 +12,9 @@ use League\OpenAPIValidation\Schema\SchemaValidator;
 use Respect\Validation\Validator;
 use Throwable;
 
+use function in_array;
+use function is_array;
+use function is_string;
 use function sprintf;
 
 class Items extends BaseKeyword
@@ -46,7 +49,19 @@ class Items extends BaseKeyword
             throw InvalidSchema::becauseDefensiveSchemaValidationFailed($e);
         }
 
-        if (! isset($this->parentSchema->type) || ($this->parentSchema->type !== 'array')) {
+        if (
+            ! isset($this->parentSchema->type)
+            || (
+                (
+                    is_string($this->parentSchema->type)
+                    && $this->parentSchema->type !== 'array'
+                )
+                || (
+                    is_array($this->parentSchema->type)
+                    && in_array('array', $this->parentSchema->type) === false
+                )
+            )
+        ) {
             throw new InvalidSchema(sprintf('items MUST be present if the type is array'));
         }
 


### PR DESCRIPTION
When usign to validate a schema with a nullable array 
```php
class foo
{ 
    /** @var ?array $bar */
   protetected ?array $bar;
   }
   ```
   The type is an array with the values `array' and `null` on the OpenApi 3.1
   
   With this fix, we check if the type is string or an array. 