### PR TITLE
Bug Fix: Incorrect Static Paths Prioritising

### DIFF
--- a/src/PSR7/OperationAddress.php
+++ b/src/PSR7/OperationAddress.php
@@ -28,6 +28,8 @@ class OperationAddress
     protected $method;
     /** @var string */
     protected $path;
+    /** @var string */
+    protected $fullPath;
 
     public function __construct(string $path, string $method)
     {
@@ -63,6 +65,18 @@ class OperationAddress
         return $this->path;
     }
 
+    public function fullPath(): string
+    {
+        return $this->fullPath;
+    }
+
+    public function setFullPath(string $fullPath): self
+    {
+        $this->fullPath = $fullPath;
+
+        return $this;
+    }
+
     public function hasPlaceholders(): bool
     {
         return (bool) $this->countPlaceholders();
@@ -76,7 +90,7 @@ class OperationAddress
     public function countExactMatchParts(string $comparisonPath): int
     {
         $comparisonPathParts = explode('/', trim($comparisonPath, '/'));
-        $pathParts           = explode('/', trim($this->path(), '/'));
+        $pathParts           = explode('/', trim($this->fullPath(), '/'));
         $exactMatchCount     = 0;
         foreach ($comparisonPathParts as $key => $comparisonPathPart) {
             if ($comparisonPathPart !== $pathParts[$key]) {

--- a/src/PSR7/PathFinder.php
+++ b/src/PSR7/PathFinder.php
@@ -114,7 +114,7 @@ class PathFinder
                 }
 
                 // path matched!
-                $paths[] = $opCandidate['addr'];
+                $paths[] = $opCandidate['addr']->setFullPath($candidatePath);
                 break;
             }
         }
@@ -230,7 +230,7 @@ class PathFinder
         $partCounts        = [];
         $placeholderCounts = [];
         foreach ($paths as $path) {
-            $partCounts[]        = $this->countParts($path->path());
+            $partCounts[]        = $this->countParts($path->fullPath());
             $placeholderCounts[] = $path->countPlaceholders();
         }
 

--- a/tests/PSR7/PathFinderTest.php
+++ b/tests/PSR7/PathFinderTest.php
@@ -125,6 +125,8 @@ info:
   title: Uber API
   description: Move your app forward with the Uber API
   version: "1.0.0"
+servers:
+  - url: https://localhost/v1
 paths:
   /products/{product}/images/{image}:
     get:
@@ -134,7 +136,7 @@ paths:
       summary: All thumbnail images for a specific product
 SPEC;
 
-        $pathFinder = new PathFinder(Reader::readFromYaml($spec), '/products/10/images/thumbnails', 'get');
+        $pathFinder = new PathFinder(Reader::readFromYaml($spec), '/v1/products/10/images/thumbnails', 'get');
         $opAddrs    = $pathFinder->search();
 
         $this->assertCount(1, $opAddrs);


### PR DESCRIPTION
**Problem:**  
When OpenAPI `servers` are defined and there are multiple paths with the same number of segments—some dynamic and some static—the validator may incorrectly match both paths.

**Example OpenAPI definition:**
```yaml
servers:
  - url: https://localhost/v1

paths:
  get /products/{product}/images/{image}
  get /products/{product}/images/thumbnails
```

**Incoming request:**
```
GET /v1/products/10/images/thumbnails
```

**Actual behavior:**  
Both paths `/products/{product}/images/{image}` and `/products/{product}/images/thumbnails` are matched.

**Expected behavior:**  
Only the more specific, static path `/products/{product}/images/thumbnails` should match.

**Cause:**  
The current path matching logic compares only the relative path without properly including the server prefix (e.g., `/v1`). This leads to ambiguous or incorrect matching when evaluating path candidates of equal length.

**Fix:**  
Ensure that the matching logic compares full paths—including the server prefix—when determining the best match.
