### PR TITLE
Add type validation before explode `value`

### DIFF
--- a/src/PSR7/Validators/SerializedParameter.php
+++ b/src/PSR7/Validators/SerializedParameter.php
@@ -267,6 +267,10 @@ final class SerializedParameter
     {
         if (in_array($this->style, [self::STYLE_FORM, self::STYLE_SPACE_DELIMITED, self::STYLE_PIPE_DELIMITED], true)) {
             if ($this->explode === false) {
+                if (! is_string($value)) {
+                    throw TypeMismatch::becauseTypeDoesNotMatch(['string'], $value);
+                }
+
                 $value = explode(self::STYLE_DELIMITER_MAP[$this->style], $value);
             }
 


### PR DESCRIPTION
## Issue example

In `openapi.yml` documentation:
```yaml
parameters:
  name: parameterName
  in: query
  explode: false
  schema:
    type: array
    items:
      type: string
```

In this case, the `parameter` is expected to be in the following format:
```url
https://example.com/api/endpoint?parameterName=value1,value2,value3
```

However, if an invalid request is made like this:
```url
https://example.com/api/endpoint?parameterName[]=value1&parameterName[]=value2
```
then `$value = explode(self::STYLE_DELIMITER_MAP[$this->style], $value);` will try to `explode` array and in PHP 8 throws fatal error: `Fatal error: Uncaught TypeError: explode(): Argument #2 ($string) must be of type string, array given`

## Fix
Check that `$value` is a string before `explode()`.