### PR TITLE
ISSUE-248: Update SpecFinder.php

### DIFF
--- a/src/PSR7/SpecFinder.php
+++ b/src/PSR7/SpecFinder.php
@@ -155,11 +155,11 @@ final class SpecFinder
         $securitySpecs = $opSpec->security;
 
         // security is set on operation level
-        if (is_array($securitySpecs)) {
-            return $securitySpecs;
+        if (!empty($securitySpecs)) {
+            return (array) $securitySpecs;
         }
 
-        return $this->openApi->security;
+        return (array) $this->openApi->security;
     }
 
     /**


### PR DESCRIPTION
See #248 

Simply cast to (array) to make it work with OpenAPI pre 1.8 and 1.8 without breaking the current validation logic.