### PR TITLE
Upgrade ci php versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,14 +63,14 @@ jobs:
         run: ./vendor/bin/phpunit -c phpunit.xml
 
   cs:
-    name: Codestyle check on PHP 8.3
+    name: Codestyle check on PHP 7.2
     runs-on: ubuntu-latest
 
     steps:
       - name: Set up PHP
         uses: shivammathur/setup-php@2.33.0
         with:
-          php-version: 8.3
+          php-version: 7.2
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -88,7 +88,7 @@ jobs:
     strategy:
       matrix:
         php:
-          - '8.3'
+          - '7.2'
 
     steps:
       - name: Set up PHP

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,22 @@ jobs:
             composer-options: "--ignore-platform-reqs"
             experimental: true
             dependencies: "highest"
+          - php: "8.2"
+            composer-options: "--ignore-platform-reqs"
+            experimental: true
+            dependencies: "highest"
+          - php: "8.3"
+            composer-options: "--ignore-platform-reqs"
+            experimental: true
+            dependencies: "highest"
+          - php: "8.4"
+            composer-options: "--ignore-platform-reqs"
+            experimental: true
+            dependencies: "highest"
 
     steps:
       - name: Set up PHP
-        uses: shivammathur/setup-php@2.9.0
+        uses: shivammathur/setup-php@2.33.0
         with:
           php-version: ${{ matrix.php }}
           extensions: intl, mbstring
@@ -51,14 +63,14 @@ jobs:
         run: ./vendor/bin/phpunit -c phpunit.xml
 
   cs:
-    name: Codestyle check on PHP 7.2
+    name: Codestyle check on PHP 8.3
     runs-on: ubuntu-latest
 
     steps:
       - name: Set up PHP
-        uses: shivammathur/setup-php@2.1.0
+        uses: shivammathur/setup-php@2.33.0
         with:
-          php-version: 7.2
+          php-version: 8.3
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -76,11 +88,11 @@ jobs:
     strategy:
       matrix:
         php:
-          - '7.2'
+          - '8.3'
 
     steps:
       - name: Set up PHP
-        uses: shivammathur/setup-php@2.1.0
+        uses: shivammathur/setup-php@2.33.0
         with:
           php-version: ${{ matrix.php }}
 


### PR DESCRIPTION
Upgrade to use the latest php versions, so we can be more sure any fixes should work on a nice range of php versions.

Seem to be all passing on my fork, upgraded `shivammathur/setup-php` too while at it since presumably there's some performance gains hidden in there.