### PR TITLE
fix: #259 The HTTP Authentication Scheme patterns should be case-inse…

### DIFF
--- a/src/PSR7/Validators/SecurityValidator.php
+++ b/src/PSR7/Validators/SecurityValidator.php
@@ -26,8 +26,8 @@ use function sprintf;
 final class SecurityValidator implements MessageValidator
 {
     private const HEADER_AUTHORIZATION = 'Authorization';
-    private const AUTH_PATTERN_BASIC   = '#^Basic #';
-    private const AUTH_PATTERN_BEARER  = '#^Bearer #';
+    private const AUTH_PATTERN_BASIC   = '#^Basic #i';
+    private const AUTH_PATTERN_BEARER  = '#^Bearer #i';
 
     /** @var SpecFinder */
     private $finder;


### PR DESCRIPTION
We were running into random "None of security schemas did match for …" validation errors. This was being caused by the `League\OpenAPIValidation\PSR7\Validators\SecurityValidator:: AUTH_PATTERN_*` patterns, which do not have the case-insensitivity flag (`i`) set.

The `basic` and `bearer` authentication scheme tokens should be considered case-insensitive per [Section 2.1 of RFC 7235](https://datatracker.ietf.org/doc/html/rfc7235#section-2.1). So this PR adds the `i` flag so that the matching is done in a case-insensitive manner.