### PR TITLE
Add a .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# https://php.watch/articles/composer-gitattributes
+
+# Exclude build/test files from usual installs
+/.githooks        export-ignore
+/.github          export-ignore
+/tests            export-ignore
+.gitattributes    export-ignore
+.gitignore        export-ignore
+phpcs.xml         export-ignore
+phpstan.neon      export-ignore
+phpunit.xml       export-ignore


### PR DESCRIPTION
Added to prevent typical composer installation from having more project specific files in their vendor directory. Saves a decent amount of network traffic + saves storage when installed (well, people could post-install remove these files but why put up with that bother).

(Resolves issue #253)